### PR TITLE
client class: add relay agent operator & sub-opt postfix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,16 +731,24 @@ dependencies = [
 
 [[package]]
 name = "dhcproto"
-version = "0.9.0-alpha"
-source = "git+https://github.com/bluecatengineering/dhcproto#195f6f41d2721e46fefad07644e825f936f6d9d8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcee045385d5f7819022821f41209b9945d17550760b0b2349aaef4ecfa14bc3"
 dependencies = [
+ "dhcproto-macros",
  "hex",
  "ipnet",
  "rand",
  "thiserror",
- "trust-dns-proto 0.21.2",
+ "trust-dns-proto 0.22.0",
  "url",
 ]
+
+[[package]]
+name = "dhcproto-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7993efb860416547839c115490d4951c6d0f8ec04a3594d9dd99d50ed7ec170"
 
 [[package]]
 name = "digest"
@@ -866,9 +874,9 @@ dependencies = [
 
 [[package]]
 name = "enum-as-inner"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21cdad81446a7f7dc43f6a77409efeb9733d2fa65553efef6018ef257c959b73"
+checksum = "c9720bba047d567ffc8a3cba48bf19126600e249ab7f128e9233e6376976a116"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3369,25 +3377,25 @@ dependencies = [
 
 [[package]]
 name = "trust-dns-proto"
-version = "0.21.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c31f240f59877c3d4bb3b3ea0ec5a6a0cff07323580ff8c7a605cd7d08b255d"
+checksum = "4f7f83d1e4a0e4358ac54c5c3681e5d7da5efc5a7a632c90bb6d6669ddd9bc26"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner 0.4.0",
+ "enum-as-inner 0.5.1",
  "futures-channel",
  "futures-io",
  "futures-util",
  "idna 0.2.3",
  "ipnet",
  "lazy_static",
- "log",
  "rand",
  "smallvec",
  "thiserror",
  "tinyvec",
+ "tracing",
  "url",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,13 +45,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
+name = "anes"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anyhow"
@@ -74,7 +71,7 @@ dependencies = [
  "parking",
  "polling",
  "slab",
- "socket2 0.4.7",
+ "socket2 0.4.9",
  "waker-fn",
  "winapi",
 ]
@@ -136,7 +133,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -149,9 +146,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.1"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08b108ad2665fa3f6e6a517c3d80ec3e77d224c47d605167aefaa5d7ef97fa48"
+checksum = "8582122b8edba2af43eaf6b80dbfd33f421b5a0eb3a3113d21bc096ac5b44faf"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -161,7 +158,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "itoa 1.0.4",
+ "itoa",
  "matchit",
  "memchr",
  "mime",
@@ -182,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.3.0"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b8558f5a0581152dc94dcd289132a1d377494bdeafcd41869b3258e3e2ad92"
+checksum = "b2f958c80c248b34b9a877a643811be8dbca03ca5ba827f2b63baf3a81e5fc4e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -202,6 +199,12 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "bit-set"
@@ -231,18 +234,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "bstr"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
-dependencies = [
- "lazy_static",
- "memchr",
- "regex-automata",
- "serde",
 ]
 
 [[package]]
@@ -362,14 +353,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "2.34.0"
+name = "ciborium"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
 dependencies = [
- "bitflags",
- "textwrap 0.11.0",
- "unicode-width",
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -378,27 +385,22 @@ version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
- "atty",
  "bitflags",
- "clap_derive 3.2.18",
  "clap_lex 0.2.4",
  "indexmap",
- "once_cell",
- "strsim",
- "termcolor",
- "textwrap 0.16.0",
+ "textwrap",
 ]
 
 [[package]]
 name = "clap"
-version = "4.0.26"
+version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2148adefda54e14492fb9bddcc600b4344c5d1a3123bd666dcb939c6f0e0e57e"
+checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
 dependencies = [
- "atty",
  "bitflags",
- "clap_derive 4.0.21",
+ "clap_derive",
  "clap_lex 0.3.0",
+ "is-terminal",
  "once_cell",
  "strsim",
  "termcolor",
@@ -406,22 +408,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
+checksum = "44bec8e5c9d09e439c4335b1af0abaab56dcf3b94999a936e1bb47b9134288f0"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -484,7 +473,7 @@ name = "config"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.21.0",
  "client-classification",
  "dora-core",
  "hex",
@@ -527,15 +516,16 @@ checksum = "ccaeedb56da03b09f598226e25e80088cb4cd25f316e6e4df7d695f0feeb1403"
 
 [[package]]
 name = "criterion"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
+checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
 dependencies = [
+ "anes",
  "atty",
  "cast",
- "clap 2.34.0",
+ "ciborium",
+ "clap 3.2.23",
  "criterion-plot",
- "csv",
  "itertools",
  "lazy_static",
  "num-traits",
@@ -544,7 +534,6 @@ dependencies = [
  "rayon",
  "regex",
  "serde",
- "serde_cbor",
  "serde_derive",
  "serde_json",
  "tinytemplate",
@@ -553,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools",
@@ -625,28 +614,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "csv"
-version = "1.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
-dependencies = [
- "bstr",
- "csv-core",
- "itoa 0.4.8",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "cxx"
 version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.12.4"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2c43f534ea4b0b049015d00269734195e6d3f0f6635cb692251aca6f9f8b3c"
+checksum = "c0808e1bd8671fb44a113a14e13497557533369847788fa2ae912b6ebfce9fa8"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -702,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.12.4"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e91455b86830a1c21799d94524df0845183fa55bafd9aa137b01c7d1065fa36"
+checksum = "001d80444f28e193f30c2f293455da62dcf9a6b29918a4253152ae2b1de592cb"
 dependencies = [
  "fnv",
  "ident_case",
@@ -716,9 +683,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.12.4"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
+checksum = "b36230598a2d5de7ec1c6f51f72d8a99a9208daff41de2084d06e3fd3ea56685"
 dependencies = [
  "darling_core",
  "quote",
@@ -733,18 +700,18 @@ checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "derive_builder"
-version = "0.10.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d13202debe11181040ae9063d739fa32cfcaaebe2275fe387703460ae2365b30"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
 dependencies = [
  "derive_builder_macro",
 ]
 
 [[package]]
 name = "derive_builder_core"
-version = "0.10.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66e616858f6187ed828df7c64a6d71720d83767a7f19740b2d1b6fe6327b36e5"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -754,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "derive_builder_macro"
-version = "0.10.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58a94ace95092c5acb1e97a7e846b310cfbd499652f72297da7493f618a98d73"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
 dependencies = [
  "derive_builder_core",
  "syn",
@@ -810,7 +777,7 @@ dependencies = [
  "mac_address",
  "message-type",
  "rand",
- "socket2 0.4.7",
+ "socket2 0.4.9",
  "static-addr",
  "tracing-futures",
  "tracing-test",
@@ -821,7 +788,7 @@ name = "dora-cfg"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap 3.2.23",
+ "clap 4.1.8",
  "config",
  "jsonschema",
  "serde",
@@ -838,7 +805,7 @@ dependencies = [
  "bytes",
  "chrono",
  "chrono-tz",
- "clap 3.2.23",
+ "clap 4.1.8",
  "dhcproto",
  "env-parser",
  "futures",
@@ -849,7 +816,7 @@ dependencies = [
  "prometheus",
  "prometheus-static-metric",
  "rand",
- "socket2 0.4.7",
+ "socket2 0.4.9",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -857,7 +824,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-futures",
- "tracing-subscriber 0.3.16",
+ "tracing-subscriber",
  "unix-udp-sock",
 ]
 
@@ -914,6 +881,27 @@ name = "env-parser"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -1003,12 +991,6 @@ dependencies = [
  "lazy_static",
  "num",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
 
 [[package]]
 name = "futures"
@@ -1147,9 +1129,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
@@ -1219,6 +1201,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1237,13 +1225,13 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.4",
+ "itoa",
 ]
 
 [[package]]
@@ -1277,9 +1265,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.23"
+version = "0.14.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
+checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1290,9 +1278,9 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.4",
+ "itoa",
  "pin-project-lite",
- "socket2 0.4.7",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -1343,11 +1331,11 @@ dependencies = [
  "parking_lot 0.12.1",
  "pnet",
  "rand",
- "socket2 0.4.7",
+ "socket2 0.4.9",
  "thiserror",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.16",
+ "tracing-subscriber",
  "tracing-test",
 ]
 
@@ -1398,6 +1386,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+dependencies = [
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "ip-manager"
 version = "0.1.0"
 dependencies = [
@@ -1435,11 +1433,23 @@ dependencies = [
 
 [[package]]
 name = "ipnetwork"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f84f1612606f3753f205a4e9a2efd6fe5b4c573a6269b2cc6c3003d44a0d127"
+checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1462,32 +1472,25 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
-
-[[package]]
-name = "itoa"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "jemalloc-sys"
-version = "0.3.2"
+version = "0.5.3+5.3.0-patched"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
+checksum = "f9bd5d616ea7ed58b571b2e209a65759664d7fb021a0819d7a790afc67e47ca1"
 dependencies = [
  "cc",
- "fs_extra",
  "libc",
 ]
 
 [[package]]
 name = "jemallocator"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
+checksum = "16c2514137880c52b0b4822b563fadd38257c1f380858addb74a400889696ea6"
 dependencies = [
  "jemalloc-sys",
  "libc",
@@ -1510,13 +1513,13 @@ checksum = "6ca9e2b45609132ae2214d50482c03aeee78826cd6fd53a8940915b81acedf16"
 dependencies = [
  "ahash 0.8.2",
  "anyhow",
- "base64",
+ "base64 0.13.1",
  "bytecount",
- "clap 4.0.26",
+ "clap 4.1.8",
  "fancy-regex",
  "fraction",
  "iso8601",
- "itoa 1.0.4",
+ "itoa",
  "lazy_static",
  "memchr",
  "num-cmp",
@@ -1552,9 +1555,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1581,6 +1584,12 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "lock_api"
@@ -1634,15 +1643,6 @@ name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
-
-[[package]]
-name = "matchers"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
-dependencies = [
- "regex-automata",
-]
 
 [[package]]
 name = "matchers"
@@ -1710,14 +1710,14 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
 name = "moka"
-version = "0.9.6"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b49a05f67020456541f4f29cbaa812016a266a86ec76f96d3873d459c68fe5e"
+checksum = "2b6446f16d504e3d575df79cabb11bfbe9f24b17e9562d964a815db7b28ae3ec"
 dependencies = [
  "async-io",
  "async-lock",
@@ -1866,7 +1866,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -1945,7 +1945,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2120,9 +2120,9 @@ dependencies = [
 
 [[package]]
 name = "pnet"
-version = "0.31.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0caaf5b11fd907ff15cf14a4477bfabca4b37ab9e447a4f8dead969a59cdafad"
+checksum = "cd959a8268165518e2bf5546ba84c7b3222744435616381df3c456fe8d983576"
 dependencies = [
  "ipnetwork",
  "pnet_base",
@@ -2134,9 +2134,9 @@ dependencies = [
 
 [[package]]
 name = "pnet_base"
-version = "0.31.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d3a993d49e5fd5d4d854d6999d4addca1f72d86c65adf224a36757161c02b6"
+checksum = "872e46346144ebf35219ccaa64b1dffacd9c6f188cd7d012bd6977a2a838f42e"
 dependencies = [
  "no-std-net",
  "serde",
@@ -2144,9 +2144,9 @@ dependencies = [
 
 [[package]]
 name = "pnet_datalink"
-version = "0.31.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e466faf03a98ad27f6e15cd27a2b7cc89e73e640a43527742977bc503c37f8aa"
+checksum = "c302da22118d2793c312a35fb3da6846cb0fab6c3ad53fd67e37809b06cdafce"
 dependencies = [
  "ipnetwork",
  "libc",
@@ -2158,9 +2158,9 @@ dependencies = [
 
 [[package]]
 name = "pnet_macros"
-version = "0.31.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48dd52a5211fac27e7acb14cfc9f30ae16ae0e956b7b779c8214c74559cef4c3"
+checksum = "2a780e80005c2e463ec25a6e9f928630049a10b43945fea83207207d4a7606f4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2170,18 +2170,18 @@ dependencies = [
 
 [[package]]
 name = "pnet_macros_support"
-version = "0.31.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89de095dc7739349559913aed1ef6a11e73ceade4897dadc77c5e09de6740750"
+checksum = "e6d932134f32efd7834eb8b16d42418dac87086347d1bc7d142370ef078582bc"
 dependencies = [
  "pnet_base",
 ]
 
 [[package]]
 name = "pnet_packet"
-version = "0.31.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc3b5111e697c39c8b9795b9fdccbc301ab696699e88b9ea5a4e4628978f495f"
+checksum = "8bde678bbd85cb1c2d99dc9fc596e57f03aa725f84f3168b0eaf33eeccb41706"
 dependencies = [
  "glob",
  "pnet_base",
@@ -2191,9 +2191,9 @@ dependencies = [
 
 [[package]]
 name = "pnet_sys"
-version = "0.31.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "328e231f0add6d247d82421bf3790b4b33b39c8930637f428eef24c4c6a90805"
+checksum = "faf7a58b2803d818a374be9278a1fe8f88fce14b936afbe225000cfcd9c73f16"
 dependencies = [
  "libc",
  "winapi",
@@ -2201,9 +2201,9 @@ dependencies = [
 
 [[package]]
 name = "pnet_transport"
-version = "0.31.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff597185e6f1f5671b3122e4dba892a1c73e17c17e723d7669bd9299cbe7f124"
+checksum = "813d1c0e4defbe7ee22f6fe1755f122b77bfb5abe77145b1b5baaf463cab9249"
 dependencies = [
  "libc",
  "pnet_base",
@@ -2257,9 +2257,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -2332,9 +2332,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -2411,9 +2411,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2468,7 +2468,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2536,12 +2536,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.36.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "rustls"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "log",
  "ring",
  "sct 0.6.1",
@@ -2566,7 +2580,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
 dependencies = [
- "base64",
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -2642,28 +2656,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half",
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2676,7 +2680,7 @@ version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e8b3801309262e8184d9687fb697586833e939767aea0dda89f5a8e650e8bd7"
 dependencies = [
- "itoa 1.0.4",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -2697,7 +2701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.4",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -2792,9 +2796,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
@@ -2861,7 +2865,7 @@ dependencies = [
  "hashlink",
  "hex",
  "indexmap",
- "itoa 1.0.4",
+ "itoa",
  "libc",
  "libsqlite3-sys",
  "log",
@@ -2944,9 +2948,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2986,15 +2990,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -3096,9 +3091,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.2"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
+checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3109,9 +3104,9 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.4.7",
+ "socket2 0.4.9",
  "tokio-macros",
- "winapi",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -3203,9 +3198,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.3.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
+checksum = "5d1d42a9b3f3ec46ba828e8d376aec14592ea199f70a06a548587ecd1c4ab658"
 dependencies = [
  "bitflags",
  "bytes",
@@ -3299,33 +3294,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
-dependencies = [
- "ansi_term",
- "chrono",
- "lazy_static",
- "matchers 0.0.1",
- "regex",
- "serde",
- "serde_json",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-serde",
-]
-
-[[package]]
-name = "tracing-subscriber"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
 dependencies = [
- "matchers 0.1.0",
+ "matchers",
  "nu-ansi-term",
  "once_cell",
  "regex",
@@ -3342,21 +3315,21 @@ dependencies = [
 
 [[package]]
 name = "tracing-test"
-version = "0.1.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3b48778c2d401c6a7fcf38a0e3c55dc8e8e753cbd381044a8cdb6fd69a29f53"
+checksum = "3a2c0ff408fe918a94c428a3f2ad04e4afd5c95bbc08fcf868eff750c15728a4"
 dependencies = [
  "lazy_static",
  "tracing-core",
- "tracing-subscriber 0.2.25",
+ "tracing-subscriber",
  "tracing-test-macro",
 ]
 
 [[package]]
 name = "tracing-test-macro"
-version = "0.1.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c49adbab879d2e0dd7f75edace5f0ac2156939ecb7e6a1e8fa14e53728328c48"
+checksum = "258bc1c4f8e2e73a977812ab339d503e6feeb92700f6d07a6de4d321522d5c08"
 dependencies = [
  "lazy_static",
  "quote",
@@ -3515,16 +3488,16 @@ checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "unix-udp-sock"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de9a466c0fbb15988b8708bba0809f2264cdee632590639ce51a7bc0f80d2e38"
+checksum = "f3c047b54fcdda2aa4d4feffde101e8742570134e1840ef2a0d26b75cbfd2ba6"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "libc",
  "pin-project-lite",
- "socket2 0.4.7",
+ "socket2 0.4.9",
  "tokio",
  "tokio-util",
  "tracing",
@@ -3789,46 +3762,70 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+name = "windows-sys"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = "1.0"
 async-trait = "0.1"
 bytes = "1.1"
 clap = { version = "4.1.8", features = ["derive", "env"] }
-dhcproto = { git = "https://github.com/bluecatengineering/dhcproto" }
+dhcproto = "0.9.0"
 futures = { version = "0.3", default-features = false, features = ["std"] }
 ipnet = { features = ["serde"], version = "2.4.0" }
 pnet = { features = ["serde", "std"], version = "0.33.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,25 +13,25 @@ members = [
 ]
 # default-members = ["bin"]
 
-
 [workspace.dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-serde_yaml = "0.8"
-clap = { version = "3.2.4", features = ["derive", "env"] }
 bytes = "1.1"
+clap = { version = "4.1.8", features = ["derive", "env"] }
 dhcproto = { git = "https://github.com/bluecatengineering/dhcproto" }
 futures = { version = "0.3", default-features = false, features = ["std"] }
-tokio = { version = "1.17.0", features = [ "full" ] }
+ipnet = { features = ["serde"], version = "2.4.0" }
+pnet = { features = ["serde", "std"], version = "0.33.0" }
+prometheus = "0.13.0"
+prometheus-static-metric = "0.5"
+tokio = { version = "1.26.0", features = [ "full" ] }
 tracing = "0.1.22"
 tracing-futures = "0.2"
 tracing-subscriber = { features = ["env-filter", "json"], version = "0.3" }
 thiserror = "1.0"
-prometheus = "0.13.0"
-prometheus-static-metric = "0.5"
 rand = "0.8"
-pnet = { features = ["serde", "std"], version = "0.31.0" }
-ipnet = { features = ["serde"], version = "2.4.0" }
+socket2 = { version = "0.4.9", features = ["all"] } # TODO: update when tokio sockets impl AsFd, then update unix-udp-sock
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+serde_yaml = "0.8"
 

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -23,14 +23,14 @@ dotenv = "0.15.0"
 
 [dev-dependencies]
 mac_address = "1.1.1"
-derive_builder = "0.10"
+derive_builder = "0.12.0"
 crossbeam-channel = "0.5.1"
 rand = "0.8"
-socket2 = { version = "0.4", features = ["all"] }
-tracing-test = "0.1"
+socket2 = { workspace = true }
+tracing-test = "0.2.4"
 
 [target.'cfg(not(target_env = "musl"))'.dependencies]
-jemallocator = { version = "0.3.2", features = ["background_threads"] }
+jemallocator = { version = "0.5.0", features = ["background_threads"] }
 
 [[bin]]
 name = "dora"

--- a/dora-cfg/src/main.rs
+++ b/dora-cfg/src/main.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use clap::{ArgEnum, Parser};
+use clap::{Parser, ValueEnum};
 
 use config::wire;
 use serde::de::DeserializeOwned;
@@ -14,14 +14,14 @@ pub struct Args {
     #[clap(short = 'p', long, value_parser)]
     pub path: PathBuf,
     /// print the parsed wire format or the dora internal config format
-    #[clap(short = 'f', long, arg_enum, value_parser)]
+    #[clap(short = 'f', long, value_parser)]
     pub format: Option<Format>,
     /// path to JSON schema. Config must be in JSON format and use `.json` extension
     #[clap(short = 's', long, value_parser)]
     pub schema: Option<PathBuf>,
 }
 
-#[derive(Parser, Debug, Clone, PartialEq, Eq, ArgEnum)]
+#[derive(Parser, Debug, Clone, PartialEq, Eq, ValueEnum)]
 pub enum Format {
     Wire,
     Internal,

--- a/dora-core/Cargo.toml
+++ b/dora-core/Cargo.toml
@@ -32,9 +32,9 @@ prometheus = { workspace = true }
 prometheus-static-metric = { workspace = true }
 rand = { workspace = true }
 clap = { workspace = true }
-socket2 = { version = "0.4.4", features = ["all"] }
+socket2 = { workspace = true }
 libc = "0.2.126"
-unix-udp-sock = "0.4.0"
+unix-udp-sock = "0.6.0"
 pnet = { workspace = true }
 
 [dev-dependencies]

--- a/external-api/Cargo.toml
+++ b/external-api/Cargo.toml
@@ -12,7 +12,7 @@ dora-core = { path = "../dora-core" }
 
 # libs
 anyhow = { workspace = true }
-axum = "0.6.1"
+axum = "0.6.10"
 tokio = { workspace = true }
 tracing-futures = { workspace = true }
 tracing = { workspace = true }

--- a/libs/client-classification/Cargo.toml
+++ b/libs/client-classification/Cargo.toml
@@ -13,7 +13,7 @@ hex = "0.4.3"
 dhcproto = { workspace = true }
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.4.0"
 
 [[bench]]
 name = "my_benchmark"

--- a/libs/client-classification/src/ast.rs
+++ b/libs/client-classification/src/ast.rs
@@ -25,7 +25,7 @@ pub fn build_ast(pair: Pairs<Rule>) -> ParseResult<Expr> {
         .op(Op::infix(Rule::and, Assoc::Left))
         .op(Op::infix(Rule::equal, Assoc::Right) | Op::infix(Rule::neq, Assoc::Right))
         .op(Op::prefix(Rule::not))
-        .op(Op::postfix(Rule::to_hex) | Op::postfix(Rule::exists));
+        .op(Op::postfix(Rule::to_hex) | Op::postfix(Rule::exists) | Op::postfix(Rule::sub_opt));
 
     parse_expr(pair, &climber)
 }
@@ -39,28 +39,34 @@ pub enum Val {
     Int(u32),
 }
 
+impl std::fmt::Display for Val {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
 fn is_bool(val: Val) -> EvalResult<bool> {
     match val {
         Val::Bool(b) => Ok(b),
-        err => Err(EvalErr::ExpectedBool(format!("{err:?}"))),
+        err => Err(EvalErr::ExpectedBool(err)),
     }
 }
 fn is_str(val: Val) -> EvalResult<String> {
     match val {
         Val::String(s) => Ok(s),
-        err => Err(EvalErr::ExpectedString(format!("{err:?}"))),
+        err => Err(EvalErr::ExpectedString(err)),
     }
 }
 fn is_int(val: Val) -> EvalResult<u32> {
     match val {
         Val::Int(i) => Ok(i),
-        err => Err(EvalErr::ExpectedInt(format!("{err:?}"))),
+        err => Err(EvalErr::ExpectedInt(err)),
     }
 }
 fn is_empty(val: Val) -> EvalResult<()> {
     match val {
         Val::Empty => Ok(()),
-        err => Err(EvalErr::ExpectedEmpty(format!("{err:?}"))),
+        err => Err(EvalErr::ExpectedEmpty(err)),
     }
 }
 
@@ -111,8 +117,19 @@ pub fn eval_ast(
             Val::String(s) => Val::Bytes(s.as_bytes().to_vec()),
             Val::Bytes(b) => Val::Bytes(b),
             Val::Int(i) => Val::Bytes(i.to_be_bytes().to_vec()),
-            err => return Err(EvalErr::ExpectedBytes(format!("{err:?}"))),
+            err => return Err(EvalErr::ExpectedBytes(err)),
         },
+        SubOpt(lhs, o) => {
+            let bytes = match eval_ast(*lhs, chaddr, opts)? {
+                Val::String(s) => s.as_bytes().to_vec(),
+                Val::Bytes(b) => b,
+                err => return Err(EvalErr::ExpectedBytes(err)),
+            };
+            match parse_sub_opts(&bytes, o)? {
+                Some(v) => Val::Bytes(v),
+                None => Val::Empty,
+            }
+        }
         // infix
         And(lhs, rhs) => Val::Bool(
             is_bool(eval_ast(*lhs, chaddr, opts)?)? && is_bool(eval_ast(*rhs, chaddr, opts)?)?,
@@ -124,7 +141,7 @@ pub fn eval_ast(
             Val::String(a) => match eval_ast(*rhs, chaddr, opts)? {
                 Val::String(b) => a == b,
                 Val::Bytes(b) => a.as_bytes() == b,
-                err => return Err(EvalErr::ExpectedString(format!("{err:?}"))),
+                err => return Err(EvalErr::ExpectedString(err)),
             },
             Val::Bool(a) => a == is_bool(eval_ast(*rhs, chaddr, opts)?)?,
             Val::Int(a) => a == is_int(eval_ast(*rhs, chaddr, opts)?)?,
@@ -132,14 +149,14 @@ pub fn eval_ast(
             Val::Bytes(a) => match eval_ast(*rhs, chaddr, opts)? {
                 Val::String(b) => a == b.as_bytes(),
                 Val::Bytes(b) => a == b,
-                err => return Err(EvalErr::ExpectedBytes(format!("{err:?}"))),
+                err => return Err(EvalErr::ExpectedBytes(err)),
             },
         }),
         NEqual(lhs, rhs) => Val::Bool(match eval_ast(*lhs, chaddr, opts)? {
             Val::String(a) => match eval_ast(*rhs, chaddr, opts)? {
                 Val::String(b) => a != b,
                 Val::Bytes(b) => a.as_bytes() != b,
-                err => return Err(EvalErr::ExpectedString(format!("{err:?}"))),
+                err => return Err(EvalErr::ExpectedString(err)),
             },
             Val::Bool(a) => a != is_bool(eval_ast(*rhs, chaddr, opts)?)?,
             Val::Int(a) => a != is_int(eval_ast(*rhs, chaddr, opts)?)?,
@@ -147,7 +164,7 @@ pub fn eval_ast(
             Val::Bytes(a) => match eval_ast(*rhs, chaddr, opts)? {
                 Val::String(b) => a != b.as_bytes(),
                 Val::Bytes(b) => a != b,
-                err => return Err(EvalErr::ExpectedBytes(format!("{err:?}"))),
+                err => return Err(EvalErr::ExpectedBytes(err)),
             },
         }),
         Substring(lhs, i, j) => {
@@ -167,7 +184,6 @@ fn parse_expr(pairs: Pairs<Rule>, pratt: &PrattParser<Rule>) -> ParseResult<Expr
                     "false" => false,
                     err => return Err(ParseErr::Bool(err.to_string())),
                 }),
-                // Rule::mac => Expr::Mac(),
                 Rule::pkt_mac => Expr::Mac(),
                 Rule::ip => Expr::Ip(primary.as_str().parse()?),
                 Rule::string => Expr::String(
@@ -209,7 +225,14 @@ fn parse_expr(pairs: Pairs<Rule>, pratt: &PrattParser<Rule>) -> ParseResult<Expr
             Ok(match op.as_rule() {
                 Rule::to_hex => Expr::ToHex(Box::new(lhs?)),
                 Rule::exists => Expr::Exists(Box::new(lhs?)),
-                // Rule::sub_opt => Expr::SubOpt(Box::new(lhs?)),
+                Rule::sub_opt => {
+                    // parse inner op (".option[_]"), should return Expr::Option(_)
+                    let sub_opt = match parse_expr(op.into_inner(), pratt)? {
+                        Expr::Option(n) => n,
+                        other => return Err(ParseErr::Option(other)),
+                    };
+                    Expr::SubOpt(Box::new(lhs?), sub_opt)
+                }
                 rule => return Err(ParseErr::Undefined(rule)),
             })
         })
@@ -296,6 +319,54 @@ mod tests {
         let expr = super::parse("relay4[12].hex == 'foo'").unwrap();
         let val = eval_ast(expr, "001122334455", &options).unwrap();
         assert_eq!(val, Val::Bool(true));
+    }
+
+    #[test]
+    fn test_sub_opts_postfix() {
+        let mut options = HashMap::new();
+        let mut data: Vec<u8> = vec![12];
+
+        let sub_opt = "foo".as_bytes();
+        data.push(sub_opt.len() as u8);
+        data.extend(sub_opt);
+        data.extend(&[
+            23, 3, 1, 2, 3, // two
+            45, 0, // three
+            123, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+        ]);
+
+        options.insert(
+            v4::OptionCode::RelayAgentInformation,
+            UnknownOption::new(v4::OptionCode::RelayAgentInformation, data),
+        );
+        // test that we can address sub options through the sub-opt postfix
+        let expr = super::parse("option[82].option[12] == 'foo'").unwrap();
+        let val = eval_ast(expr, "001122334455", &options).unwrap();
+        assert_eq!(val, Val::Bool(true));
+
+        let expr = super::parse("option[82].option[23].hex").unwrap();
+        let val = eval_ast(expr, "001122334455", &options).unwrap();
+        assert_eq!(val, Val::Bytes(vec![1, 2, 3]));
+
+        let expr = super::parse("option[82].option[23].exists").unwrap();
+        let val = eval_ast(expr, "001122334455", &options).unwrap();
+        assert_eq!(val, Val::Bool(true));
+
+        let expr = super::parse("option[82].option[25].exists").unwrap();
+        let val = eval_ast(expr, "001122334455", &options).unwrap();
+        assert_eq!(val, Val::Bool(false));
+
+        // the parent opt 81 does not exist, no sub-opts to address
+        let expr = super::parse("option[81].option[25].exists").unwrap();
+        let val = eval_ast(expr, "001122334455", &options);
+        // should error
+        assert!(val.is_err());
+        if let Err(err) = val {
+            match err {
+                EvalErr::ExpectedBytes(b) => assert_eq!(b, Val::Empty),
+                _ => panic!("must be expectedbytes"),
+            }
+        };
     }
 
     #[test]

--- a/libs/client-classification/src/grammar.pest
+++ b/libs/client-classification/src/grammar.pest
@@ -17,6 +17,7 @@ operation = _{ equal | neq | and | or }
 
 
 option = { "option[" ~ integer ~ "]" }
+relay = { "relay4[" ~ integer ~ "]" }
 
 pkt = _{ pkt_mac }
     pkt_mac = @{ "pkt4.mac" }
@@ -31,8 +32,9 @@ prefix = _{ not }
 postfix  =  _{ to_hex | exists }
     to_hex    =   { ".hex" } 
     exists    =   { ".exists" } 
+    // sub_opt    =   { "." ~ option } 
 
-primary = _{ hex | ip | integer | string | boolean | option | pkt | substring | "(" ~ expr ~ ")" }
+primary = _{ hex | ip | integer | string | boolean | option | relay | pkt | substring | "(" ~ expr ~ ")" }
 predicate = _{ SOI ~ expr ~ EOI }
 
 WHITESPACE = _{ " " | "\t" | "\r" | "\n" }

--- a/libs/client-classification/src/grammar.pest
+++ b/libs/client-classification/src/grammar.pest
@@ -29,10 +29,10 @@ expr = { prefix* ~ primary ~ postfix* ~ (operation ~ prefix* ~ primary ~ postfix
 prefix = _{ not }
     not = { "not" } 
 
-postfix  =  _{ to_hex | exists }
+postfix  =  _{ to_hex | exists | sub_opt }
     to_hex    =   { ".hex" } 
     exists    =   { ".exists" } 
-    // sub_opt    =   { "." ~ option } 
+    sub_opt    =   { "." ~ option } 
 
 primary = _{ hex | ip | integer | string | boolean | option | relay | pkt | substring | "(" ~ expr ~ ")" }
 predicate = _{ SOI ~ expr ~ EOI }

--- a/libs/client-classification/src/lib.rs
+++ b/libs/client-classification/src/lib.rs
@@ -12,6 +12,7 @@ pub enum Expr {
     Hex(String),
     Bool(bool),
     Option(u8),
+    Relay(u8),
     Mac(),
     // operation
     Substring(Box<Expr>, usize, usize),
@@ -20,6 +21,7 @@ pub enum Expr {
     // postfix
     ToHex(Box<Expr>),
     Exists(Box<Expr>),
+    // SubOpt(Box<Expr>, u8),
     // infix
     And(Box<Expr>, Box<Expr>),
     Or(Box<Expr>, Box<Expr>),
@@ -61,4 +63,6 @@ pub enum EvalErr {
     ExpectedEmpty(String),
     #[error("expected ip: got {0}")]
     ExpectedBytes(String),
+    #[error("failed to get sub-opt")]
+    SubOptionParseFail(#[from] dhcproto::error::DecodeError),
 }

--- a/libs/client-classification/src/lib.rs
+++ b/libs/client-classification/src/lib.rs
@@ -2,6 +2,8 @@ use std::net::Ipv4Addr;
 
 use thiserror::Error;
 
+use crate::ast::Val;
+
 pub mod ast;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -21,7 +23,7 @@ pub enum Expr {
     // postfix
     ToHex(Box<Expr>),
     Exists(Box<Expr>),
-    // SubOpt(Box<Expr>, u8),
+    SubOpt(Box<Expr>, u8),
     // infix
     And(Box<Expr>, Box<Expr>),
     Or(Box<Expr>, Box<Expr>),
@@ -29,9 +31,15 @@ pub enum Expr {
     NEqual(Box<Expr>, Box<Expr>),
 }
 
+impl std::fmt::Display for Expr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
 pub type ParseResult<T> = Result<T, ParseErr>;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq)]
 pub enum ParseErr {
     #[error("float parse error")]
     Float(#[from] std::num::ParseFloatError),
@@ -41,6 +49,8 @@ pub enum ParseErr {
     Ip(#[from] std::net::AddrParseError),
     #[error("substring parse error with: {0}")]
     Substring(String),
+    #[error("expected option but found: {0}")]
+    Option(Expr),
     #[error("bool parse error with: {0}")]
     Bool(String),
     #[error("undefined with: {0:?}")]
@@ -54,15 +64,15 @@ pub type EvalResult<T> = Result<T, EvalErr>;
 #[derive(Error, Debug)]
 pub enum EvalErr {
     #[error("expected bool: got {0}")]
-    ExpectedBool(String),
+    ExpectedBool(Val),
     #[error("expected string: got {0}")]
-    ExpectedString(String),
+    ExpectedString(Val),
     #[error("expected int: got {0}")]
-    ExpectedInt(String),
+    ExpectedInt(Val),
     #[error("expected ip: got {0}")]
-    ExpectedEmpty(String),
+    ExpectedEmpty(Val),
     #[error("expected ip: got {0}")]
-    ExpectedBytes(String),
+    ExpectedBytes(Val),
     #[error("failed to get sub-opt")]
     SubOptionParseFail(#[from] dhcproto::error::DecodeError),
 }

--- a/libs/config/Cargo.toml
+++ b/libs/config/Cargo.toml
@@ -13,7 +13,7 @@ tracing = { workspace = true }
 serde_yaml = { workspace = true }
 serde_json = { workspace = true }
 serde = { workspace = true }
-base64 = "0.13"
+base64 = "0.21.0"
 hex = "0.4"
 
 dora-core = { path = "../../dora-core" }

--- a/libs/config/src/wire/v4.rs
+++ b/libs/config/src/wire/v4.rs
@@ -39,6 +39,7 @@
 use std::{collections::HashMap, net::Ipv4Addr, ops::RangeInclusive};
 
 use anyhow::Result;
+use base64::Engine;
 use dora_core::{
     dhcproto::{
         v4::{DhcpOption, DhcpOptions, OptionCode},
@@ -216,7 +217,7 @@ fn write_opt(enc: &mut Encoder<'_>, code: u8, opt: Opt) -> anyhow::Result<()> {
             enc.write_u16(n)?;
         }
         Opt::B64(s) => {
-            let bytes = base64::decode(s)?;
+            let bytes = base64::engine::general_purpose::STANDARD_NO_PAD.decode(s)?;
             enc.write_u8(bytes.len() as u8)?;
             enc.write_slice(&bytes)?;
         }

--- a/libs/config/src/wire/v6.rs
+++ b/libs/config/src/wire/v6.rs
@@ -1,3 +1,4 @@
+use base64::Engine;
 use dora_core::dhcproto::{
     v6::{DhcpOption, DhcpOptions, OptionCode},
     Decodable, Decoder, Encodable, Encoder,
@@ -160,7 +161,7 @@ fn write_opt(enc: &mut Encoder<'_>, code: u16, opt: Opt) -> anyhow::Result<()> {
             enc.write_slice(s.as_bytes())?;
         }
         Opt::B64(s) => {
-            let bytes = base64::decode(s)?;
+            let bytes = base64::engine::general_purpose::STANDARD_NO_PAD.decode(s)?;
             enc.write_u16(bytes.len() as u16)?;
             enc.write_slice(&bytes)?;
         }

--- a/libs/icmp-ping/Cargo.toml
+++ b/libs/icmp-ping/Cargo.toml
@@ -8,7 +8,7 @@ license = "MPL-2.0"
 
 [dependencies]
 rand = "0.8"
-socket2 = { version = "0.4", features = ["all"] }
+socket2 = { workspace = true }
 tokio = { version = "1.17.0", features = ["time", "net", "sync", "macros"] }
 parking_lot = "0.12"
 pnet = { workspace = true }
@@ -18,4 +18,4 @@ tracing ={ workspace = true }
 [dev-dependencies]
 tokio = { version = "1.17.0", features = ["full"] }
 tracing-subscriber = "0.3"
-tracing-test = "0.1"
+tracing-test = "0.2.4"

--- a/libs/ip-manager/Cargo.toml
+++ b/libs/ip-manager/Cargo.toml
@@ -15,6 +15,6 @@ ipnet = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 chrono = "0.4.19"
-moka = { version = "0.9.2", features = ["future"] }
+moka = { version = "0.10.0", features = ["future"] }
 # TODO: hopefully the rustls feature can go away, the lib requires it
 sqlx = { version = "0.5.13", features = ["sqlite", "runtime-tokio-rustls", "chrono", "offline"] }


### PR DESCRIPTION
We need a way to address sub-opts through the client class syntax. 

This PR adds `relay4[_]` syntax from kea, for addressing dhcpv4 relay agent sub-opts.

It also adds a general sub-option postfix operator. Kea does this with `option[123].option[1]` where the `.option[1]` postfix is the sub-option operator. This has been added to dora also. The following expressions are now possible:

```
option[82].option[12] == 'foo'

option[82].option[12].exists

relay4[12].hex == 0x123
```

All options values, as well as `.hex` postfix simply turns the value into a byte string for comparison.