### PR TITLE
client class: add pkt4.* tokens

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -39,8 +39,6 @@ jobs:
       matrix:
         rust:
           - stable
-          - beta
-          - nightly
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2

--- a/libs/client-classification/benches/my_benchmark.rs
+++ b/libs/client-classification/benches/my_benchmark.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use client_classification::ast;
 use criterion::{criterion_group, criterion_main, Criterion};
-use dhcproto::v4::UnknownOption;
+use dhcproto::v4::{self, UnknownOption};
 use pest::Parser;
 
 // use client_classification::{one, two};
@@ -30,6 +30,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     client_classification::ast::build_ast(tokens).unwrap(),
                     chaddr,
                     &options,
+                    &v4::Message::default(),
                 )
                 .unwrap()
             })
@@ -54,7 +55,13 @@ fn criterion_benchmark(c: &mut Criterion) {
                     UnknownOption::new(61.into(), b"some_client_id".to_vec()),
                 );
 
-                client_classification::ast::eval_ast(ast.clone(), chaddr, &options).unwrap()
+                client_classification::ast::eval_ast(
+                    ast.clone(),
+                    chaddr,
+                    &options,
+                    &v4::Message::default(),
+                )
+                .unwrap()
             })
         },
     );

--- a/libs/client-classification/src/grammar.pest
+++ b/libs/client-classification/src/grammar.pest
@@ -19,8 +19,26 @@ operation = _{ equal | neq | and | or }
 option = { "option[" ~ integer ~ "]" }
 relay = { "relay4[" ~ integer ~ "]" }
 
-pkt = _{ pkt_mac }
+pkt = _{ 
+    pkt_mac
+    | pkt_hlen
+    | pkt_htype
+    | pkt_ciaddr
+    | pkt_giaddr
+    | pkt_yiaddr
+    | pkt_siaddr
+    | pkt_msgtype
+    | pkt_transid
+}
     pkt_mac = @{ "pkt4.mac" }
+    pkt_hlen = @{ "pkt4.hlen" }
+    pkt_htype = @{ "pkt4.htype" }
+    pkt_ciaddr = @{ "pkt4.ciaddr" }
+    pkt_giaddr = @{ "pkt4.giaddr" }
+    pkt_yiaddr = @{ "pkt4.yiaddr" }
+    pkt_siaddr = @{ "pkt4.siaddr" }
+    pkt_msgtype = @{ "pkt4.msgtype" }
+    pkt_transid = @{ "pkt4.transid" }
 
 substring = { "substring(" ~ expr ~ "," ~ integer ~ "," ~ integer ~ ")" }
 

--- a/libs/client-classification/src/lib.rs
+++ b/libs/client-classification/src/lib.rs
@@ -16,6 +16,14 @@ pub enum Expr {
     Option(u8),
     Relay(u8),
     Mac(),
+    Hlen(),
+    HType(),
+    CiAddr(),
+    GiAddr(),
+    YiAddr(),
+    SiAddr(),
+    MsgType(),
+    TransId(),
     // operation
     Substring(Box<Expr>, usize, usize),
     // prefix


### PR DESCRIPTION
Adds the following tokens to the client class expression:
```
    pkt_hlen = @{ "pkt4.hlen" }
    pkt_htype = @{ "pkt4.htype" }
    pkt_ciaddr = @{ "pkt4.ciaddr" }
    pkt_giaddr = @{ "pkt4.giaddr" }
    pkt_yiaddr = @{ "pkt4.yiaddr" }
    pkt_siaddr = @{ "pkt4.siaddr" }
    pkt_msgtype = @{ "pkt4.msgtype" }
    pkt_transid = @{ "pkt4.transid" }
 ```

The eval function now takes a DHCP `Message` so that these values can be pulled out. Most are turned into an integer representation. If compared with a hex or slice of bytes, they will be converted into a byte string also.