### PR TITLE
v4: RFC 1497 BOOTP impl

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ It will pretty-print the internal dora config representation as well as parse th
 
 #### v4
 
+-   [v4 RFC1497](https://datatracker.ietf.org/doc/html/rfc1497)
 -   [v4 RFC2131](https://datatracker.ietf.org/doc/html/rfc2131)
 -   [v4 RFC2132](https://datatracker.ietf.org/doc/html/rfc2132)
 -   [v4 RFC3011](https://datatracker.ietf.org/doc/html/rfc3011)

--- a/bin/tests/test_configs/basic.yaml
+++ b/bin/tests/test_configs/basic.yaml
@@ -1,4 +1,5 @@
 chaddr_only: false
+bootp_enable: true
 interfaces: 
     - dhcpsrv
 networks:
@@ -94,6 +95,22 @@ networks:
                                 - 10.10.0.1
                 match:
                     chaddr: aa:bb:cc:dd:ee:ff
+            -
+                ip: 192.168.2.165
+                config:
+                    lease_time:
+                        default: 3600
+                options:
+                    values:
+                        1:
+                            type: ip
+                            value: 10.10.0.1
+                        3:
+                            type: ip_list
+                            value:
+                                - 10.10.0.1
+                match:
+                    chaddr: bb:bb:cc:dd:ee:ff
     10.0.0.0/16:
         ranges:
             -

--- a/example.yaml
+++ b/example.yaml
@@ -5,6 +5,12 @@
 #
 # chaddr_only: false
 #
+# Enable BOOTP support. Dora supports only RFC1497. BOOTP clients
+# will be assigned an IP based on their chaddr, they don't have client-ids.
+# The `lease_time` property of a reservation will be ignored
+#
+# bootp_enable: false
+#
 # Dora binds to inaddr_any, if an interface is specified dora will filter 
 # all traffic not from this interface.
 # If no interface is specified, we will listen on inaddr_any (0.0.0.0) and send
@@ -42,13 +48,15 @@ networks:
         # OR IF IT IS NOT specified, dora will use the IP of the interface we recv'd the message on. 
         # OR we will just use the first non-loopback interface IP
         server_id: 192.168.5.1
-        # this will replace the `sname` field in the DHCP header
+        # (optional) this will replace the `sname` field in the DHCP header
         # server_name: "example.org"
         #
-        # this will replace the `fname` field in the DHCP header
+        # (optional) this will replace the `fname` field in the DHCP header
         # file_name: "bootfile.efi" 
         ranges:
             -
+                # (optional) specifies the class name that must have been matched on
+                class: "my_class"
                 # start of your range
                 start: 192.168.5.2
                 # end of your range

--- a/libs/config/src/v4.rs
+++ b/libs/config/src/v4.rs
@@ -31,6 +31,7 @@ pub struct Config {
     /// are up & ipv4
     interfaces: Vec<NetworkInterface>,
     chaddr_only: bool,
+    bootp_enable: bool,
     /// used to make a selection on which network or subnet to use
     networks: HashMap<Ipv4Net, Network>,
     v6: Option<crate::v6::Config>,
@@ -107,6 +108,7 @@ impl TryFrom<wire::Config> for Config {
             interfaces,
             networks,
             chaddr_only: cfg.chaddr_only,
+            bootp_enable: cfg.bootp_enable,
             v6: cfg
                 .v6
                 .map(crate::v6::Config::try_from)
@@ -159,7 +161,8 @@ impl Config {
             })
         })
     }
-    // find the interface at the index `iface_index`
+
+    /// find the interface at the index `iface_index`
     fn find_interface(&self, iface_index: u32) -> Option<&NetworkInterface> {
         self.interfaces.iter().find(|e| e.index == iface_index)
     }
@@ -167,6 +170,11 @@ impl Config {
     /// Whether the server is configured to use `chaddr` only or look at Client ID
     pub fn chaddr_only(&self) -> bool {
         self.chaddr_only
+    }
+
+    /// Whether the server is configured to use bootp
+    pub fn bootp_enabled(&self) -> bool {
+        self.bootp_enable
     }
 
     /// If opt 61 (client id) exists return that, otherwise return `chaddr` from the message

--- a/libs/config/src/wire/mod.rs
+++ b/libs/config/src/wire/mod.rs
@@ -15,6 +15,8 @@ pub struct Config {
     pub interfaces: Option<Vec<String>>,
     #[serde(default = "default_chaddr_only")]
     pub chaddr_only: bool,
+    #[serde(default = "default_bootp_enable")]
+    pub bootp_enable: bool,
     #[serde(default)]
     pub networks: HashMap<Ipv4Net, v4::Net>,
     pub v6: Option<v6::Config>,
@@ -44,7 +46,7 @@ pub const fn default_chaddr_only() -> bool {
     false
 }
 
-pub const fn default_enable_ra() -> bool {
+pub const fn default_bootp_enable() -> bool {
     false
 }
 

--- a/libs/config/src/wire/v4.rs
+++ b/libs/config/src/wire/v4.rs
@@ -29,6 +29,10 @@
 //! the server to only look at the `chaddr` field. Setting `chaddr_only` to true
 //! will do that.
 //!
+//! ## BOOTP enable
+//!
+//! Enable BOOTP for dora, only support for RFC1497.
+//!
 //! ## Authoritative
 //!
 //! When the DHCP server is configured as authoritative, the server will respond with

--- a/plugins/leases/src/lib.rs
+++ b/plugins/leases/src/lib.rs
@@ -18,7 +18,7 @@ use std::{
 use dora_core::{
     anyhow::anyhow,
     chrono::{DateTime, SecondsFormat, Utc},
-    dhcproto::v4::{DhcpOption, Message, MessageType, Opcode, OptionCode},
+    dhcproto::v4::{DhcpOption, Message, MessageType, OptionCode},
     prelude::*,
 };
 use message_type::MatchedClasses;

--- a/plugins/leases/src/lib.rs
+++ b/plugins/leases/src/lib.rs
@@ -18,7 +18,7 @@ use std::{
 use dora_core::{
     anyhow::anyhow,
     chrono::{DateTime, SecondsFormat, Utc},
-    dhcproto::v4::{DhcpOption, Message, MessageType, OptionCode},
+    dhcproto::v4::{DhcpOption, Message, MessageType, Opcode, OptionCode},
     prelude::*,
 };
 use message_type::MatchedClasses;

--- a/plugins/message-type/src/lib.rs
+++ b/plugins/message-type/src/lib.rs
@@ -140,7 +140,7 @@ impl Plugin<Message> for MsgType {
                     return Ok(Action::NoResponse);
                 }
             }
-            None if req.opcode() == Opcode::BootRequest => {
+            None if req.opcode() == Opcode::BootRequest && self.cfg.v4().bootp_enabled() => {
                 // No message type but BOOTREQUEST, this is a BOOTP message
                 ctx.set_decoded_resp_msg(resp);
                 return Ok(Action::Continue);

--- a/plugins/message-type/src/lib.rs
+++ b/plugins/message-type/src/lib.rs
@@ -55,7 +55,8 @@ impl Plugin<Message> for MsgType {
 
         let subnet = ctx.subnet()?;
         debug!(
-            msg_type = ?msg_type.context("messages must have a type")?,
+            opcode = ?req.opcode(),
+            msg_type = ?msg_type,
             src_addr = %ctx.src_addr(),
             ?subnet,
             req = %ctx.decoded_msg(),
@@ -88,34 +89,36 @@ impl Plugin<Message> for MsgType {
             .insert(DhcpOption::ServerIdentifier(server_id));
         // evaluate client classes
         let matched = util::client_classes(self.cfg.v4(), req);
-
-        match msg_type.context("no option 53 (message type) found")? {
-            MessageType::Discover => {
+        let addr = {
+            let ciaddr = ctx.decoded_msg().ciaddr();
+            if !ciaddr.is_unspecified() {
+                ciaddr
+            } else {
+                // TODO: when `subnet` is used to select a range, it probably doesn't exist.
+                subnet
+            }
+        };
+        match msg_type {
+            Some(MessageType::Discover) => {
                 resp.opts_mut()
                     .insert(DhcpOption::MessageType(MessageType::Offer));
             }
-            MessageType::Request => {
+            Some(MessageType::Request) => {
                 if !req.giaddr().is_unspecified() {
                     resp.set_flags(req.flags().set_broadcast());
                 }
                 resp.opts_mut()
                     .insert(DhcpOption::MessageType(MessageType::Ack));
             }
-            MessageType::Release => {
+            Some(MessageType::Release) => {
                 resp.opts_mut()
                     .insert(DhcpOption::MessageType(MessageType::Ack));
             }
             // got INFORM & we are authoritative, give a response
-            MessageType::Inform if matches!(network, Some(net) if net.authoritative()) => {
+            Some(MessageType::Inform) if matches!(network, Some(net) if net.authoritative()) => {
                 resp.opts_mut()
                     .insert(DhcpOption::MessageType(MessageType::Ack));
-                let ciaddr = ctx.decoded_msg().ciaddr();
-                let addr = if !ciaddr.is_unspecified() {
-                    ciaddr
-                } else {
-                    // TODO: when `subnet` is used to select a range, it probably doesn't exist.
-                    subnet
-                };
+
                 if let Some(range) = self.cfg.v4().range(addr, addr, matched.as_deref()) {
                     ctx.set_decoded_resp_msg(resp);
                     ctx.populate_opts(
@@ -125,7 +128,7 @@ impl Plugin<Message> for MsgType {
                 }
                 warn!(msg_type = ?MessageType::Inform, "couldn't match appropriate range with INFORM message");
             }
-            MessageType::Decline => {
+            Some(MessageType::Decline) => {
                 if let Some(DhcpOption::RequestedIpAddress(ip)) =
                     req.opts().get(OptionCode::RequestedIpAddress)
                 {
@@ -136,6 +139,11 @@ impl Plugin<Message> for MsgType {
                     error!("got DECLINE with no option 50 (requested IP)");
                     return Ok(Action::NoResponse);
                 }
+            }
+            None if req.opcode() == Opcode::BootRequest => {
+                // No message type but BOOTREQUEST, this is a BOOTP message
+                ctx.set_decoded_resp_msg(resp);
+                return Ok(Action::Continue);
             }
             _ => {
                 debug!("unsupported message type");

--- a/plugins/static-addr/src/lib.rs
+++ b/plugins/static-addr/src/lib.rs
@@ -49,30 +49,31 @@ impl Plugin<Message> for StaticAddr {
                 let mac = MacAddr::new(
                     chaddr[0], chaddr[1], chaddr[2], chaddr[3], chaddr[4], chaddr[5],
                 );
+                let bootp = self.cfg.v4().bootp_enabled();
                 if let Some(res) = net.get_reserved_mac(mac, classes) {
                     // mac is present in our config
-                    match req.opts().msg_type().context("no message type found")? {
-                        MessageType::Discover => self.discover(ctx, &chaddr, classes, res)?,
-                        MessageType::Request => self.request(ctx, &chaddr, classes, res)?,
+                    return match req.opts().msg_type() {
+                        Some(MessageType::Discover) => self.discover(ctx, &chaddr, classes, res),
+                        Some(MessageType::Request) => self.request(ctx, &chaddr, classes, res),
+                        // no message type, but BOOTP enabled
+                        None if bootp => self.bootp(ctx, &chaddr, classes, res),
                         // we have a reservation, but we didn't et a DISCOVER or REQUEST
                         // drop the message
-                        _ => return Ok(Action::NoResponse),
+                        _ => Ok(Action::NoResponse),
                     };
-                    return Ok(Action::Continue);
                 }
             }
 
             // determine if we have a reservation based on opt
             if let Some(res) = net.search_reserved_opt(req.opts(), classes) {
                 // matching opt is present in our config
-                match req.opts().msg_type().context("no message type found")? {
-                    MessageType::Discover => self.discover(ctx, &chaddr, classes, res)?,
-                    MessageType::Request => self.request(ctx, &chaddr, classes, res)?,
+                return match req.opts().msg_type().context("no message type found")? {
+                    MessageType::Discover => self.discover(ctx, &chaddr, classes, res),
+                    MessageType::Request => self.request(ctx, &chaddr, classes, res),
                     // we have a reservation, but we didn't et a DISCOVER or REQUEST
                     // drop the message
-                    _ => return Ok(Action::NoResponse),
+                    _ => Ok(Action::NoResponse),
                 };
-                return Ok(Action::Continue);
             }
         }
         Ok(Action::Continue)
@@ -80,7 +81,6 @@ impl Plugin<Message> for StaticAddr {
 }
 
 impl StaticAddr {
-    #[inline]
     fn discover(
         &self,
         ctx: &mut MsgContext<Message>,
@@ -92,7 +92,7 @@ impl StaticAddr {
         let (lease, t1, t2) = res.lease().determine_lease(ctx.requested_lease_time());
         debug!(?static_ip, ?chaddr, "use static requested ip");
         ctx.decoded_resp_msg_mut()
-            .context("response message must be set before leases is run")?
+            .context("response message must be set before static is run")?
             .set_yiaddr(static_ip);
         ctx.populate_opts_lease(
             &self.cfg.v4().collect_opts(res.opts(), classes),
@@ -103,7 +103,27 @@ impl StaticAddr {
         Ok(Action::Continue)
     }
 
-    #[inline]
+    /// populate BOOTP response. Some clients only accept messages with a min size of 300 bytes,
+    /// that is not handled here. We would need to insert PAD opts until the byte size is reached.
+    fn bootp(
+        &self,
+        ctx: &mut MsgContext<Message>,
+        chaddr: &[u8],
+        classes: Option<&[String]>,
+        res: &Reserved,
+    ) -> Result<Action> {
+        let static_ip = res.ip();
+        debug!(?static_ip, ?chaddr, "BOOTREPLY using static ip");
+        ctx.decoded_resp_msg_mut()
+            .context("response message must be set before static is run")?
+            .set_yiaddr(static_ip);
+        // populate opts with no lease time info
+        ctx.populate_opts(&self.cfg.v4().collect_opts(res.opts(), classes));
+        // remove options that aren't allowed in a BOOTP response
+        ctx.filter_dhcp_opts();
+        Ok(Action::Respond)
+    }
+
     fn request(
         &self,
         ctx: &mut MsgContext<Message>,


### PR DESCRIPTION
Adds the `bootp_enable` flag to config root, which, when enabled will allow `reservations` to be given to BOOTP clients if the client's MAC matches. Responses will have options filtered out that are not supported (from RFC1533):

```
{
    DHO_DHCP_REQUESTED_ADDRESS,
    DHO_DHCP_LEASE_TIME,
    DHO_DHCP_OPTION_OVERLOAD,
    DHO_DHCP_MESSAGE_TYPE,
    DHO_DHCP_SERVER_IDENTIFIER,
    DHO_DHCP_PARAMETER_REQUEST_LIST,
    DHO_DHCP_MESSAGE,
    DHO_DHCP_MAX_MESSAGE_SIZE,
    DHO_DHCP_RENEWAL_TIME,
    DHO_DHCP_REBINDING_TIME,
    DHO_DHCP_CLIENT_IDENTIFIER
}
```

Future work items:
- RFC 951 is not currently supported, if that is desired, changes will probably need to be made to dhcproto.
- client class support, would be good to distinguish between BOOTP / DHCP in client classes
- Pad BOOTP packets to their minimum size of 300 bytes (only some devices require this)




