### PR TITLE
draft: client class member() function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,6 +481,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "topo_sort",
  "tracing",
 ]
 
@@ -830,6 +831,7 @@ dependencies = [
  "tokio-stream",
  "tokio-test",
  "tokio-util",
+ "topo_sort",
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
@@ -3186,6 +3188,13 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "topo_sort"
+version = "0.1.0"
+dependencies = [
+ "thiserror",
 ]
 
 [[package]]

--- a/dora-core/Cargo.toml
+++ b/dora-core/Cargo.toml
@@ -11,6 +11,7 @@ license = "MPL-2.0"
 [dependencies]
 # local
 env-parser = { path = "../libs/env-parser" }
+topo_sort = { path = "../libs/topo_sort" }
 # third party
 async-trait = { workspace = true } 
 anyhow = { workspace = true }

--- a/dora-core/src/server/mod.rs
+++ b/dora-core/src/server/mod.rs
@@ -25,15 +25,15 @@ pub mod context;
 pub mod ioctl;
 pub mod msg;
 pub mod state;
-pub mod topo_sort;
 pub mod typemap;
 pub(crate) mod udp;
 
 use crate::{
     config::cli::{Config, ALL_DHCP_RELAY_AGENTS_AND_SERVERS},
     handler::*,
-    server::{context::MsgContext, msg::SerialMsg, topo_sort::DependencyTree, udp::UdpStream},
+    server::{context::MsgContext, msg::SerialMsg, udp::UdpStream},
 };
+use topo_sort::DependencyTree;
 
 /// Handy type alias for different `handle` traits
 pub(crate) type PluginFn<T> = Arc<dyn Plugin<T>>;

--- a/example.yaml
+++ b/example.yaml
@@ -206,8 +206,9 @@ v6:
 
 # Example Client Classifier
 # 
-# This borrows heavily from Kea. We define in the dora config a client_classes section, 
-# where each class has a predicate. At least initially, all client classes will be evaluated when a packet is received. 
+# We define in the dora config a client_classes section, where each class has a predicate whose syntax 
+# is identical to Kea's expression syntax. At least initially, all client classes will be evaluated when a packet is received. 
+# The classes will be evaluated in topological order, according to their dependencies.
 # A range/reservation can then define a client_class field with the name of a class that will restrict 
 # that range/reservation to only allow packets that have evaluated the associated client class predicate to true.
 #
@@ -273,6 +274,9 @@ v6:
 #       pkt4.mac: chaddr in DHCP message header (`pkt4.mac == 0xDEADBEEF`)
 #   
 #   substring(expr, i, j): substring function (`substring('foobar', 0, 3) == 'foo')
+#
+#   member('classname'): reference another class using the `member()` function. Dependency
+#                   cycles will fail to parse the config. 
 # 
 # example:
 #

--- a/libs/client-classification/src/ast.rs
+++ b/libs/client-classification/src/ast.rs
@@ -1,17 +1,78 @@
-use crate::{EvalErr, EvalResult, Expr, ParseErr, ParseResult};
+use std::net::Ipv4Addr;
 
-use std::collections::HashMap;
-
-use dhcproto::{v4, Decoder};
+use pest::iterators::Pair;
 pub use pest::{
     pratt_parser::{Assoc, Op, PrattParser},
     {iterators::Pairs, Parser},
 };
 use pest_derive::Parser;
+use thiserror::Error;
 
 #[derive(Parser)]
 #[grammar = "grammar.pest"]
 pub struct PredicateParser;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Expr {
+    String(String),
+    Ip(Ipv4Addr),
+    Int(u32),
+    Hex(String),
+    Bool(bool),
+    Option(u8),
+    Member(String),
+    Relay(u8),
+    Mac(),
+    Hlen(),
+    HType(),
+    CiAddr(),
+    GiAddr(),
+    YiAddr(),
+    SiAddr(),
+    MsgType(),
+    TransId(),
+    // operation
+    Substring(Box<Expr>, usize, usize),
+    // prefix
+    Not(Box<Expr>),
+    // postfix
+    ToHex(Box<Expr>),
+    Exists(Box<Expr>),
+    SubOpt(Box<Expr>, u8),
+    // infix
+    And(Box<Expr>, Box<Expr>),
+    Or(Box<Expr>, Box<Expr>),
+    Equal(Box<Expr>, Box<Expr>),
+    NEqual(Box<Expr>, Box<Expr>),
+}
+
+impl std::fmt::Display for Expr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+pub type ParseResult<T> = Result<T, ParseErr>;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum ParseErr {
+    #[error("float parse error")]
+    Float(#[from] std::num::ParseFloatError),
+    #[error("int parse error")]
+    Int(#[from] std::num::ParseIntError),
+    #[error("addr parse error")]
+    Ip(#[from] std::net::AddrParseError),
+    #[error("substring parse error with: {0}")]
+    Substring(String),
+    #[error("expected option but found: {0}")]
+    Option(Expr),
+    #[error("bool parse error with: {0}")]
+    Bool(String),
+    #[error("undefined with: {0:?}")]
+    Undefined(Rule),
+    #[error("pest error {0:?}")]
+    PestErr(#[from] pest::error::Error<Rule>),
+}
 
 #[allow(clippy::result_large_err)]
 pub fn parse<S: AsRef<str>>(expr: S) -> ParseResult<Expr> {
@@ -28,160 +89,6 @@ pub fn build_ast(pair: Pairs<Rule>) -> ParseResult<Expr> {
         .op(Op::postfix(Rule::to_hex) | Op::postfix(Rule::exists) | Op::postfix(Rule::sub_opt));
 
     parse_expr(pair, &climber)
-}
-
-#[derive(Debug, PartialEq, Eq)]
-pub enum Val {
-    Empty,
-    Bool(bool),
-    String(String),
-    Bytes(Vec<u8>),
-    Int(u32),
-}
-
-impl std::fmt::Display for Val {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
-    }
-}
-
-fn is_bool(val: Val) -> EvalResult<bool> {
-    match val {
-        Val::Bool(b) => Ok(b),
-        err => Err(EvalErr::ExpectedBool(err)),
-    }
-}
-fn is_str(val: Val) -> EvalResult<String> {
-    match val {
-        Val::String(s) => Ok(s),
-        err => Err(EvalErr::ExpectedString(err)),
-    }
-}
-fn is_int(val: Val) -> EvalResult<u32> {
-    match val {
-        Val::Int(i) => Ok(i),
-        err => Err(EvalErr::ExpectedInt(err)),
-    }
-}
-fn is_empty(val: Val) -> EvalResult<()> {
-    match val {
-        Val::Empty => Ok(()),
-        err => Err(EvalErr::ExpectedEmpty(err)),
-    }
-}
-
-fn parse_sub_opts(buf: &[u8], sub_code: u8) -> Result<Option<Vec<u8>>, EvalErr> {
-    let mut d = Decoder::new(buf);
-    while let Ok(code) = d.read_u8() {
-        let len = d.read_u8()?;
-        if len != 0 {
-            let slice = d.read_slice(len as usize)?;
-            if sub_code == code {
-                return Ok(Some(slice.to_owned()));
-            }
-        }
-    }
-    Ok(None)
-}
-
-/// evaluate the AST, using values from this DHCP message
-pub fn eval_ast(
-    expr: Expr,
-    chaddr: &str,
-    opts: &HashMap<v4::OptionCode, v4::UnknownOption>,
-    msg: &v4::Message,
-) -> Result<Val, EvalErr> {
-    use Expr::*;
-    Ok(match expr {
-        Bool(b) => Val::Bool(b),
-        String(s) => Val::String(s.to_lowercase()),
-        Int(i) => Val::Int(i),
-        Hex(h) => Val::String(h.to_lowercase()),
-        Relay(o) => match opts
-            .get(&v4::OptionCode::RelayAgentInformation)
-            .and_then(|info| parse_sub_opts(info.data(), o).transpose())
-        {
-            Some(v) => Val::Bytes(v?),
-            None => Val::Empty,
-        },
-        Option(o) => match opts.get(&o.into()) {
-            Some(v) => Val::Bytes(v.data().to_owned()),
-            None => Val::Empty,
-        },
-        // TODO: can probably use msg.chaddr() instead of an explicit param here
-        Mac() => Val::String(chaddr.to_lowercase()),
-        Hlen() => Val::Int(msg.hlen() as u32),
-        HType() => Val::Int(u8::from(msg.htype()) as u32),
-        CiAddr() => Val::Int(u32::from(msg.ciaddr())),
-        GiAddr() => Val::Int(u32::from(msg.giaddr())),
-        YiAddr() => Val::Int(u32::from(msg.yiaddr())),
-        SiAddr() => Val::Int(u32::from(msg.siaddr())),
-        MsgType() => match msg.opts().msg_type() {
-            Some(ty) => Val::Int(u8::from(ty) as u32),
-            None => Val::Empty,
-        },
-        TransId() => Val::Int(msg.xid()),
-        Ip(ip) => Val::Int(u32::from_be_bytes(ip.octets())),
-        // prefix
-        Not(rhs) => Val::Bool(!is_bool(eval_ast(*rhs, chaddr, opts, msg)?)?),
-        // postfix
-        Exists(lhs) => Val::Bool(is_empty(eval_ast(*lhs, chaddr, opts, msg)?).is_err()),
-        ToHex(lhs) => match eval_ast(*lhs, chaddr, opts, msg)? {
-            Val::String(s) => Val::Bytes(s.as_bytes().to_vec()),
-            Val::Bytes(b) => Val::Bytes(b),
-            Val::Int(i) => Val::Bytes(i.to_be_bytes().to_vec()),
-            err => return Err(EvalErr::ExpectedBytes(err)),
-        },
-        SubOpt(lhs, o) => {
-            let bytes = match eval_ast(*lhs, chaddr, opts, msg)? {
-                Val::String(s) => s.as_bytes().to_vec(),
-                Val::Bytes(b) => b,
-                err => return Err(EvalErr::ExpectedBytes(err)),
-            };
-            match parse_sub_opts(&bytes, o)? {
-                Some(v) => Val::Bytes(v),
-                None => Val::Empty,
-            }
-        }
-        // infix
-        And(lhs, rhs) => Val::Bool(
-            is_bool(eval_ast(*lhs, chaddr, opts, msg)?)?
-                && is_bool(eval_ast(*rhs, chaddr, opts, msg)?)?,
-        ),
-        Or(lhs, rhs) => Val::Bool(
-            is_bool(eval_ast(*lhs, chaddr, opts, msg)?)?
-                || is_bool(eval_ast(*rhs, chaddr, opts, msg)?)?,
-        ),
-        Equal(lhs, rhs) => Val::Bool(eval_bool(*lhs, *rhs, chaddr, opts, msg)?),
-        NEqual(lhs, rhs) => Val::Bool(!eval_bool(*lhs, *rhs, chaddr, opts, msg)?),
-        Substring(lhs, i, j) => {
-            Val::String(is_str(eval_ast(*lhs, chaddr, opts, msg)?)?[i..j].to_string())
-        }
-    })
-}
-
-fn eval_bool(
-    lhs: Expr,
-    rhs: Expr,
-    chaddr: &str,
-    opts: &HashMap<v4::OptionCode, v4::UnknownOption>,
-    msg: &v4::Message,
-) -> Result<bool, EvalErr> {
-    Ok(match eval_ast(lhs, chaddr, opts, msg)? {
-        Val::String(a) => match eval_ast(rhs, chaddr, opts, msg)? {
-            Val::String(b) => a == b,
-            Val::Bytes(b) => a.as_bytes() == b,
-            err => return Err(EvalErr::ExpectedString(err)),
-        },
-        Val::Bool(a) => a == is_bool(eval_ast(rhs, chaddr, opts, msg)?)?,
-        Val::Int(a) => a == is_int(eval_ast(rhs, chaddr, opts, msg)?)?,
-        Val::Empty => is_empty(eval_ast(rhs, chaddr, opts, msg)?).is_ok(),
-        Val::Bytes(a) => match eval_ast(rhs, chaddr, opts, msg)? {
-            Val::String(b) => a == b.as_bytes(),
-            Val::Bytes(b) => a == b,
-            err => return Err(EvalErr::ExpectedBytes(err)),
-        },
-    })
 }
 
 #[allow(clippy::result_large_err)]
@@ -205,15 +112,10 @@ fn parse_expr(pairs: Pairs<Rule>, pratt: &PrattParser<Rule>) -> ParseResult<Expr
                 Rule::pkt_msgtype => Expr::MsgType(),
                 Rule::pkt_transid => Expr::TransId(),
                 Rule::ip => Expr::Ip(primary.as_str().parse()?),
-                Rule::string => Expr::String(
-                    primary
-                        .as_str()
-                        .trim_start_matches('\'')
-                        .trim_end_matches('\'')
-                        .to_string(),
-                ),
-                Rule::option => Expr::Option(primary.into_inner().as_str().parse()?),
-                Rule::relay => Expr::Relay(primary.into_inner().as_str().parse()?),
+                Rule::string => Expr::String(parse_string(primary)),
+                Rule::option => Expr::Option(parse_num(primary)?),
+                Rule::relay => Expr::Relay(parse_num(primary)?),
+                Rule::member => Expr::Member(parse_string_inner(primary)),
                 // trim off '0x'. hex decode?
                 Rule::hex => Expr::Hex(primary.as_str()[2..].to_string()),
                 Rule::substring => {
@@ -267,183 +169,20 @@ fn parse_expr(pairs: Pairs<Rule>, pratt: &PrattParser<Rule>) -> ParseResult<Expr
         .parse(pairs)
 }
 
-#[cfg(test)]
-mod tests {
-    use dhcproto::v4::UnknownOption;
-    use pest::Parser;
+fn parse_str(str: &str) -> String {
+    str.trim_start_matches('\'')
+        .trim_end_matches('\'')
+        .to_string()
+}
 
-    use super::*;
-    use std::{collections::HashMap, net::Ipv4Addr};
+fn parse_string(primary: Pair<Rule>) -> String {
+    parse_str(primary.as_str())
+}
 
-    #[test]
-    fn test_opt_exists() {
-        let tokens = PredicateParser::parse(Rule::expr, "not option[123].exists").unwrap();
+fn parse_string_inner(primary: Pair<Rule>) -> String {
+    parse_str(primary.into_inner().as_str())
+}
 
-        let val = eval_ast(
-            dbg!(build_ast(tokens).unwrap()),
-            "001122334455",
-            &HashMap::new(),
-            &v4::Message::default(),
-        )
-        .unwrap();
-        assert_eq!(val, Val::Bool(true));
-    }
-    #[test]
-    fn test_ip_parser() {
-        let tokens = PredicateParser::parse(Rule::expr, "100.10.10.10 == 100.10.10.10").unwrap();
-
-        let val = eval_ast(
-            build_ast(tokens).unwrap(),
-            "001122334455",
-            &HashMap::new(),
-            &v4::Message::default(),
-        )
-        .unwrap();
-        assert_eq!(val, Val::Bool(true));
-    }
-
-    #[test]
-    fn test_substring_opts() {
-        let mut options = HashMap::new();
-        options.insert(
-            61.into(),
-            UnknownOption::new(61.into(), b"some_client_id".to_vec()),
-        );
-
-        let tokens = super::parse(
-            "substring(pkt4.mac, 0, 6) == '001122' and option[61].hex == 'some_client_id'",
-        )
-        .unwrap();
-
-        let val = eval_ast(tokens, "001122334455", &options, &v4::Message::default()).unwrap();
-        assert_eq!(val, Val::Bool(true));
-    }
-
-    #[test]
-    fn test_relay_opts() {
-        let mut options = HashMap::new();
-        let mut data: Vec<u8> = vec![12];
-
-        let sub_opt = "foo".as_bytes();
-        data.push(sub_opt.len() as u8);
-        data.extend(sub_opt);
-        data.extend(&[
-            23, 3, 1, 2, 3, // two
-            45, 0, // three
-            123, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
-        ]);
-
-        options.insert(
-            v4::OptionCode::RelayAgentInformation,
-            UnknownOption::new(v4::OptionCode::RelayAgentInformation, data),
-        );
-        let expr = super::parse("relay4[12].exists").unwrap();
-        let val = eval_ast(expr, "001122334455", &options, &v4::Message::default()).unwrap();
-        assert_eq!(val, Val::Bool(true));
-
-        let expr = super::parse("relay4[12].hex == 'foo'").unwrap();
-        let val = eval_ast(expr, "001122334455", &options, &v4::Message::default()).unwrap();
-        assert_eq!(val, Val::Bool(true));
-    }
-
-    #[test]
-    fn test_sub_opts_postfix() {
-        let mut options = HashMap::new();
-        let mut data: Vec<u8> = vec![12];
-
-        let sub_opt = "foo".as_bytes();
-        data.push(sub_opt.len() as u8);
-        data.extend(sub_opt);
-        data.extend(&[
-            23, 3, 1, 2, 3, // two
-            45, 0, // three
-            123, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
-        ]);
-
-        options.insert(
-            v4::OptionCode::RelayAgentInformation,
-            UnknownOption::new(v4::OptionCode::RelayAgentInformation, data),
-        );
-        // test that we can address sub options through the sub-opt postfix
-        let expr = super::parse("option[82].option[12] == 'foo'").unwrap();
-        let val = eval_ast(expr, "001122334455", &options, &v4::Message::default()).unwrap();
-        assert_eq!(val, Val::Bool(true));
-
-        let expr = super::parse("option[82].option[23].hex").unwrap();
-        let val = eval_ast(expr, "001122334455", &options, &v4::Message::default()).unwrap();
-        assert_eq!(val, Val::Bytes(vec![1, 2, 3]));
-
-        let expr = super::parse("option[82].option[23].exists").unwrap();
-        let val = eval_ast(expr, "001122334455", &options, &v4::Message::default()).unwrap();
-        assert_eq!(val, Val::Bool(true));
-
-        let expr = super::parse("option[82].option[25].exists").unwrap();
-        let val = eval_ast(expr, "001122334455", &options, &v4::Message::default()).unwrap();
-        assert_eq!(val, Val::Bool(false));
-
-        // the parent opt 81 does not exist, no sub-opts to address
-        let expr = super::parse("option[81].option[25].exists").unwrap();
-        let val = eval_ast(expr, "001122334455", &options, &v4::Message::default());
-        // should error
-        assert!(val.is_err());
-        if let Err(err) = val {
-            match err {
-                EvalErr::ExpectedBytes(b) => assert_eq!(b, Val::Empty),
-                _ => panic!("must be expectedbytes"),
-            }
-        };
-    }
-
-    #[test]
-    fn test_sub_opts() {
-        let buf = vec![
-            12, 2, 1, 2, // one
-            23, 3, 1, 2, 3, // two
-            45, 0, // three
-            123, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
-        ];
-        assert_eq!(&parse_sub_opts(&buf, 12).unwrap().unwrap(), &[1, 2]);
-        assert_eq!(&parse_sub_opts(&buf, 23).unwrap().unwrap(), &[1, 2, 3]);
-        assert_eq!(&parse_sub_opts(&buf, 45).unwrap(), &None);
-        assert_eq!(
-            &parse_sub_opts(&buf, 123).unwrap().unwrap(),
-            &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        );
-    }
-
-    #[test]
-    fn test_msg_hdr() {
-        let options = HashMap::new();
-        let mut msg = v4::Message::new_with_id(
-            123,
-            Ipv4Addr::new(1, 2, 3, 4),
-            Ipv4Addr::new(2, 2, 2, 2),
-            Ipv4Addr::new(3, 3, 3, 3),
-            Ipv4Addr::new(4, 4, 4, 4),
-            "123456".as_bytes(),
-        );
-        msg.set_htype(v4::HType::Eth);
-        let mut opts = v4::DhcpOptions::new();
-        opts.insert(v4::DhcpOption::MessageType(v4::MessageType::Offer));
-        msg.set_opts(opts);
-
-        let expr = super::parse("pkt4.hlen == 6").unwrap();
-        let val = eval_ast(expr, "001122334455", &options, &msg).unwrap();
-        assert_eq!(val, Val::Bool(true));
-
-        let expr = super::parse("pkt4.ciaddr == 1.2.3.4").unwrap();
-        let val = eval_ast(expr, "001122334455", &options, &msg).unwrap();
-        assert_eq!(val, Val::Bool(true));
-
-        let expr = super::parse(
-            "pkt4.yiaddr == 2.2.2.2 and pkt4.siaddr == 3.3.3.3 and pkt4.giaddr == 4.4.4.4",
-        )
-        .unwrap();
-        let val = eval_ast(expr, "001122334455", &options, &msg).unwrap();
-        assert_eq!(val, Val::Bool(true));
-
-        let expr = super::parse("pkt4.msgtype == 2").unwrap();
-        let val = eval_ast(expr, "001122334455", &options, &msg).unwrap();
-        assert_eq!(val, Val::Bool(true));
-    }
+fn parse_num<F: std::str::FromStr>(primary: Pair<Rule>) -> Result<F, F::Err> {
+    primary.into_inner().as_str().parse()
 }

--- a/libs/client-classification/src/grammar.pest
+++ b/libs/client-classification/src/grammar.pest
@@ -18,6 +18,7 @@ operation = _{ equal | neq | and | or }
 
 option = { "option[" ~ integer ~ "]" }
 relay = { "relay4[" ~ integer ~ "]" }
+member = { "member(" ~ string ~ ")" }
 
 pkt = _{ 
     pkt_mac
@@ -52,7 +53,7 @@ postfix  =  _{ to_hex | exists | sub_opt }
     exists    =   { ".exists" } 
     sub_opt    =   { "." ~ option } 
 
-primary = _{ hex | ip | integer | string | boolean | option | relay | pkt | substring | "(" ~ expr ~ ")" }
+primary = _{ hex | ip | integer | string | boolean | option | relay | pkt | substring | member | "(" ~ expr ~ ")" }
 predicate = _{ SOI ~ expr ~ EOI }
 
 WHITESPACE = _{ " " | "\t" | "\r" | "\n" }

--- a/libs/client-classification/src/lib.rs
+++ b/libs/client-classification/src/lib.rs
@@ -1,71 +1,10 @@
-use std::net::Ipv4Addr;
+use std::collections::{HashMap, HashSet};
 
+use dhcproto::{v4, Decoder};
 use thiserror::Error;
 
-use crate::ast::Val;
-
 pub mod ast;
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Expr {
-    String(String),
-    Ip(Ipv4Addr),
-    Int(u32),
-    Hex(String),
-    Bool(bool),
-    Option(u8),
-    Relay(u8),
-    Mac(),
-    Hlen(),
-    HType(),
-    CiAddr(),
-    GiAddr(),
-    YiAddr(),
-    SiAddr(),
-    MsgType(),
-    TransId(),
-    // operation
-    Substring(Box<Expr>, usize, usize),
-    // prefix
-    Not(Box<Expr>),
-    // postfix
-    ToHex(Box<Expr>),
-    Exists(Box<Expr>),
-    SubOpt(Box<Expr>, u8),
-    // infix
-    And(Box<Expr>, Box<Expr>),
-    Or(Box<Expr>, Box<Expr>),
-    Equal(Box<Expr>, Box<Expr>),
-    NEqual(Box<Expr>, Box<Expr>),
-}
-
-impl std::fmt::Display for Expr {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
-    }
-}
-
-pub type ParseResult<T> = Result<T, ParseErr>;
-
-#[derive(Error, Debug, PartialEq)]
-pub enum ParseErr {
-    #[error("float parse error")]
-    Float(#[from] std::num::ParseFloatError),
-    #[error("int parse error")]
-    Int(#[from] std::num::ParseIntError),
-    #[error("addr parse error")]
-    Ip(#[from] std::net::AddrParseError),
-    #[error("substring parse error with: {0}")]
-    Substring(String),
-    #[error("expected option but found: {0}")]
-    Option(Expr),
-    #[error("bool parse error with: {0}")]
-    Bool(String),
-    #[error("undefined with: {0:?}")]
-    Undefined(ast::Rule),
-    #[error("pest error {0:?}")]
-    PestErr(#[from] pest::error::Error<ast::Rule>),
-}
+pub use ast::{Expr, ParseErr, ParseResult};
 
 pub type EvalResult<T> = Result<T, EvalErr>;
 
@@ -83,4 +22,421 @@ pub enum EvalErr {
     ExpectedBytes(Val),
     #[error("failed to get sub-opt")]
     SubOptionParseFail(#[from] dhcproto::error::DecodeError),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Val {
+    Empty,
+    Bool(bool),
+    String(String),
+    Bytes(Vec<u8>),
+    Int(u32),
+}
+
+impl std::fmt::Display for Val {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+fn is_bool(val: Val) -> EvalResult<bool> {
+    match val {
+        Val::Bool(b) => Ok(b),
+        err => Err(EvalErr::ExpectedBool(err)),
+    }
+}
+fn is_str(val: Val) -> EvalResult<String> {
+    match val {
+        Val::String(s) => Ok(s),
+        err => Err(EvalErr::ExpectedString(err)),
+    }
+}
+fn is_int(val: Val) -> EvalResult<u32> {
+    match val {
+        Val::Int(i) => Ok(i),
+        err => Err(EvalErr::ExpectedInt(err)),
+    }
+}
+fn is_empty(val: Val) -> EvalResult<()> {
+    match val {
+        Val::Empty => Ok(()),
+        err => Err(EvalErr::ExpectedEmpty(err)),
+    }
+}
+
+fn parse_sub_opts(buf: &[u8], sub_code: u8) -> Result<Option<Vec<u8>>, EvalErr> {
+    let mut d = Decoder::new(buf);
+    while let Ok(code) = d.read_u8() {
+        let len = d.read_u8()?;
+        if len != 0 {
+            let slice = d.read_slice(len as usize)?;
+            if sub_code == code {
+                return Ok(Some(slice.to_owned()));
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// get all the `member` classes used in the expression
+pub fn get_class_dependencies(expr: &Expr) -> Vec<String> {
+    use Expr::*;
+    match expr {
+        Member(s) => vec![s.to_owned()],
+        Substring(lhs, _, _) => get_class_dependencies(lhs),
+        Not(rhs) => get_class_dependencies(rhs),
+        ToHex(rhs) => get_class_dependencies(rhs),
+        Exists(rhs) => get_class_dependencies(rhs),
+        SubOpt(lhs, _) => get_class_dependencies(lhs),
+        And(lhs, rhs) => {
+            let mut r = get_class_dependencies(lhs);
+            r.append(&mut get_class_dependencies(rhs));
+            r
+        }
+        Or(lhs, rhs) => {
+            let mut r = get_class_dependencies(lhs);
+            r.append(&mut get_class_dependencies(rhs));
+            r
+        }
+        Equal(lhs, rhs) => {
+            let mut r = get_class_dependencies(lhs);
+            r.append(&mut get_class_dependencies(rhs));
+            r
+        }
+        NEqual(lhs, rhs) => {
+            let mut r = get_class_dependencies(lhs);
+            r.append(&mut get_class_dependencies(rhs));
+            r
+        }
+        _ => vec![],
+    }
+}
+
+pub struct Args<'a> {
+    pub chaddr: String,
+    pub opts: HashMap<v4::OptionCode, v4::UnknownOption>,
+    pub msg: &'a v4::Message,
+    pub deps: HashSet<String>,
+}
+
+/// evaluate the AST, using values from this DHCP message
+pub fn eval(expr: &Expr, args: &Args) -> Result<Val, EvalErr> {
+    // TODO: should this fn impl Expr and take &self?
+    use Expr::*;
+    Ok(match expr {
+        Bool(b) => Val::Bool(*b),
+        String(s) => Val::String(s.to_lowercase()),
+        Int(i) => Val::Int(*i),
+        Hex(h) => Val::String(h.to_lowercase()),
+        Relay(o) => match args
+            .opts
+            .get(&v4::OptionCode::RelayAgentInformation)
+            .and_then(|info| parse_sub_opts(info.data(), *o).transpose())
+        {
+            Some(v) => Val::Bytes(v?),
+            None => Val::Empty,
+        },
+        Option(o) => match args.opts.get(&(*o).into()) {
+            Some(v) => Val::Bytes(v.data().to_owned()),
+            None => Val::Empty,
+        },
+        // TODO: can probably use msg.chaddr() instead of an explicit param here
+        Mac() => Val::String(args.chaddr.to_lowercase()),
+        Hlen() => Val::Int(args.msg.hlen() as u32),
+        HType() => Val::Int(u8::from(args.msg.htype()) as u32),
+        CiAddr() => Val::Int(u32::from(args.msg.ciaddr())),
+        GiAddr() => Val::Int(u32::from(args.msg.giaddr())),
+        YiAddr() => Val::Int(u32::from(args.msg.yiaddr())),
+        SiAddr() => Val::Int(u32::from(args.msg.siaddr())),
+        MsgType() => match args.msg.opts().msg_type() {
+            Some(ty) => Val::Int(u8::from(ty) as u32),
+            None => Val::Empty,
+        },
+        TransId() => Val::Int(args.msg.xid()),
+        Ip(ip) => Val::Int(u32::from_be_bytes(ip.octets())),
+        // prefix
+        Not(rhs) => Val::Bool(!is_bool(eval(rhs, args)?)?),
+        // postfix
+        Exists(lhs) => Val::Bool(is_empty(eval(lhs, args)?).is_err()),
+        ToHex(lhs) => match eval(lhs, args)? {
+            Val::String(s) => Val::Bytes(s.as_bytes().to_vec()),
+            Val::Bytes(b) => Val::Bytes(b),
+            Val::Int(i) => Val::Bytes(i.to_be_bytes().to_vec()),
+            err => return Err(EvalErr::ExpectedBytes(err)),
+        },
+        SubOpt(lhs, o) => {
+            let bytes = match eval(lhs, args)? {
+                Val::String(s) => s.as_bytes().to_vec(),
+                Val::Bytes(b) => b,
+                err => return Err(EvalErr::ExpectedBytes(err)),
+            };
+            match parse_sub_opts(&bytes, *o)? {
+                Some(v) => Val::Bytes(v),
+                None => Val::Empty,
+            }
+        }
+        // infix
+        And(lhs, rhs) => Val::Bool(is_bool(eval(lhs, args)?)? && is_bool(eval(rhs, args)?)?),
+        Or(lhs, rhs) => Val::Bool(is_bool(eval(lhs, args)?)? || is_bool(eval(rhs, args)?)?),
+        Equal(lhs, rhs) => Val::Bool(eval_bool(lhs, rhs, args)?),
+        NEqual(lhs, rhs) => Val::Bool(!eval_bool(lhs, rhs, args)?),
+        Substring(lhs, i, j) => Val::String(is_str(eval(lhs, args)?)?[*i..*j].to_string()),
+        Member(s) => Val::Bool(args.deps.contains(s)),
+    })
+}
+
+fn eval_bool(lhs: &Expr, rhs: &Expr, args: &Args) -> Result<bool, EvalErr> {
+    Ok(match eval(lhs, args)? {
+        Val::String(a) => match eval(rhs, args)? {
+            Val::String(b) => a == b,
+            Val::Bytes(b) => a.as_bytes() == b,
+            err => return Err(EvalErr::ExpectedString(err)),
+        },
+        Val::Bool(a) => a == is_bool(eval(rhs, args)?)?,
+        Val::Int(a) => a == is_int(eval(rhs, args)?)?,
+        Val::Empty => is_empty(eval(rhs, args)?).is_ok(),
+        Val::Bytes(a) => match eval(rhs, args)? {
+            Val::String(b) => a == b.as_bytes(),
+            Val::Bytes(b) => a == b,
+            err => return Err(EvalErr::ExpectedBytes(err)),
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use dhcproto::v4::UnknownOption;
+    use pest::Parser;
+
+    use super::*;
+    use crate::ast::*;
+    use std::{collections::HashMap, net::Ipv4Addr};
+
+    #[test]
+    fn test_opt_exists() {
+        let tokens = PredicateParser::parse(Rule::expr, "not option[123].exists").unwrap();
+        let args = Args {
+            chaddr: "001122334455".to_owned(),
+            opts: HashMap::new(),
+            msg: &v4::Message::default(),
+            deps: HashSet::new(),
+        };
+
+        let val = eval(&dbg!(build_ast(tokens).unwrap()), &args).unwrap();
+        assert_eq!(val, Val::Bool(true));
+    }
+    #[test]
+    fn test_ip_parser() {
+        let tokens = PredicateParser::parse(Rule::expr, "100.10.10.10 == 100.10.10.10").unwrap();
+        let args = Args {
+            chaddr: "001122334455".to_owned(),
+            opts: HashMap::new(),
+            msg: &v4::Message::default(),
+            deps: HashSet::new(),
+        };
+        let val = eval(&build_ast(tokens).unwrap(), &args).unwrap();
+        assert_eq!(val, Val::Bool(true));
+    }
+
+    #[test]
+    fn test_substring_opts() {
+        let mut opts = HashMap::new();
+        opts.insert(
+            61.into(),
+            UnknownOption::new(61.into(), b"some_client_id".to_vec()),
+        );
+
+        let tokens = ast::parse(
+            "substring(pkt4.mac, 0, 6) == '001122' and option[61].hex == 'some_client_id'",
+        )
+        .unwrap();
+        let args = Args {
+            chaddr: "001122334455".to_owned(),
+            opts,
+            msg: &v4::Message::default(),
+            deps: HashSet::new(),
+        };
+        let val = eval(&tokens, &args).unwrap();
+        assert_eq!(val, Val::Bool(true));
+    }
+
+    #[test]
+    fn test_relay_opts() {
+        let mut opts = HashMap::new();
+        let mut data: Vec<u8> = vec![12];
+
+        let sub_opt = "foo".as_bytes();
+        data.push(sub_opt.len() as u8);
+        data.extend(sub_opt);
+        data.extend(&[
+            23, 3, 1, 2, 3, // two
+            45, 0, // three
+            123, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+        ]);
+
+        opts.insert(
+            v4::OptionCode::RelayAgentInformation,
+            UnknownOption::new(v4::OptionCode::RelayAgentInformation, data),
+        );
+        let args = Args {
+            chaddr: "001122334455".to_owned(),
+            opts,
+            msg: &v4::Message::default(),
+            deps: HashSet::new(),
+        };
+
+        let expr = ast::parse("relay4[12].exists").unwrap();
+        let val = eval(&expr, &args).unwrap();
+        assert_eq!(val, Val::Bool(true));
+
+        let expr = ast::parse("relay4[12].hex == 'foo'").unwrap();
+        let val = eval(&expr, &args).unwrap();
+        assert_eq!(val, Val::Bool(true));
+    }
+
+    #[test]
+    fn test_sub_opts_postfix() {
+        let mut opts = HashMap::new();
+        let mut data: Vec<u8> = vec![12];
+
+        let sub_opt = "foo".as_bytes();
+        data.push(sub_opt.len() as u8);
+        data.extend(sub_opt);
+        data.extend(&[
+            23, 3, 1, 2, 3, // two
+            45, 0, // three
+            123, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+        ]);
+
+        opts.insert(
+            v4::OptionCode::RelayAgentInformation,
+            UnknownOption::new(v4::OptionCode::RelayAgentInformation, data),
+        );
+        let args = Args {
+            chaddr: "001122334455".to_owned(),
+            opts,
+            msg: &v4::Message::default(),
+            deps: HashSet::new(),
+        };
+        // test that we can address sub options through the sub-opt postfix
+        let expr = ast::parse("option[82].option[12] == 'foo'").unwrap();
+        let val = eval(&expr, &args).unwrap();
+        assert_eq!(val, Val::Bool(true));
+
+        let expr = ast::parse("option[82].option[23].hex").unwrap();
+        let val = eval(&expr, &args).unwrap();
+        assert_eq!(val, Val::Bytes(vec![1, 2, 3]));
+
+        let expr = ast::parse("option[82].option[23].exists").unwrap();
+        let val = eval(&expr, &args).unwrap();
+        assert_eq!(val, Val::Bool(true));
+
+        let expr = ast::parse("option[82].option[25].exists").unwrap();
+        let val = eval(&expr, &args).unwrap();
+        assert_eq!(val, Val::Bool(false));
+
+        // the parent opt 81 does not exist, no sub-opts to address
+        let expr = ast::parse("option[81].option[25].exists").unwrap();
+        let val = eval(&expr, &args);
+        // should error
+        assert!(val.is_err());
+        if let Err(err) = val {
+            match err {
+                EvalErr::ExpectedBytes(b) => assert_eq!(b, Val::Empty),
+                _ => panic!("must be expectedbytes"),
+            }
+        };
+    }
+
+    #[test]
+    fn test_sub_opts() {
+        let buf = vec![
+            12, 2, 1, 2, // one
+            23, 3, 1, 2, 3, // two
+            45, 0, // three
+            123, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+        ];
+        assert_eq!(&parse_sub_opts(&buf, 12).unwrap().unwrap(), &[1, 2]);
+        assert_eq!(&parse_sub_opts(&buf, 23).unwrap().unwrap(), &[1, 2, 3]);
+        assert_eq!(&parse_sub_opts(&buf, 45).unwrap(), &None);
+        assert_eq!(
+            &parse_sub_opts(&buf, 123).unwrap().unwrap(),
+            &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        );
+    }
+
+    #[test]
+    fn test_msg_hdr() {
+        let options = HashMap::new();
+        let mut msg = v4::Message::new_with_id(
+            123,
+            Ipv4Addr::new(1, 2, 3, 4),
+            Ipv4Addr::new(2, 2, 2, 2),
+            Ipv4Addr::new(3, 3, 3, 3),
+            Ipv4Addr::new(4, 4, 4, 4),
+            "123456".as_bytes(),
+        );
+        msg.set_htype(v4::HType::Eth);
+        let mut opts = v4::DhcpOptions::new();
+        opts.insert(v4::DhcpOption::MessageType(v4::MessageType::Offer));
+        msg.set_opts(opts);
+
+        let args = Args {
+            chaddr: "001122334455".to_owned(),
+            opts: options,
+            msg: &msg,
+            deps: HashSet::new(),
+        };
+
+        let expr = ast::parse("pkt4.hlen == 6").unwrap();
+        let val = eval(&expr, &args).unwrap();
+        assert_eq!(val, Val::Bool(true));
+
+        let expr = ast::parse("pkt4.ciaddr == 1.2.3.4").unwrap();
+        let val = eval(&expr, &args).unwrap();
+        assert_eq!(val, Val::Bool(true));
+
+        let expr = ast::parse(
+            "pkt4.yiaddr == 2.2.2.2 and pkt4.siaddr == 3.3.3.3 and pkt4.giaddr == 4.4.4.4",
+        )
+        .unwrap();
+        let val = eval(&expr, &args).unwrap();
+        assert_eq!(val, Val::Bool(true));
+
+        let expr = ast::parse("pkt4.msgtype == 2").unwrap();
+        let val = eval(&expr, &args).unwrap();
+        assert_eq!(val, Val::Bool(true));
+    }
+
+    #[test]
+    fn test_class_dependencies() {
+        // let options = HashMap::new();
+        // let mut msg = v4::Message::new_with_id(
+        //     123,
+        //     Ipv4Addr::new(1, 2, 3, 4),
+        //     Ipv4Addr::new(2, 2, 2, 2),
+        //     Ipv4Addr::new(3, 3, 3, 3),
+        //     Ipv4Addr::new(4, 4, 4, 4),
+        //     "123456".as_bytes(),
+        // );
+
+        let expr = ast::parse(
+            "member('foobar') and member('bazz') and (member('bingo') or (member('bongo')))",
+        )
+        .unwrap();
+        // let val = eval_ast(&expr, "001122334455", &options, &msg).unwrap();
+        // assert_eq!(val, Val::Bool(true));
+        let deps = crate::get_class_dependencies(&expr);
+        assert_eq!(
+            deps.into_iter().collect::<std::collections::HashSet<_>>(),
+            [
+                "foobar".to_owned(),
+                "bazz".to_owned(),
+                "bingo".to_owned(),
+                "bongo".to_owned()
+            ]
+            .into_iter()
+            .collect::<std::collections::HashSet<_>>()
+        );
+    }
 }

--- a/libs/config/Cargo.toml
+++ b/libs/config/Cargo.toml
@@ -18,3 +18,4 @@ hex = "0.4"
 
 dora-core = { path = "../../dora-core" }
 client-classification = { path = "../client-classification" }
+topo_sort = { path = "../topo_sort" }

--- a/libs/config/sample/circular_deps.yaml
+++ b/libs/config/sample/circular_deps.yaml
@@ -1,0 +1,38 @@
+chaddr_only: false
+# interfaces:
+#     - wlan0
+client_classes:
+    v4:
+        -
+          name: my_class
+          assert: "member('c_class')"
+          options:
+                values:
+                    6:
+                        type: ip_list
+                        value: [ 1.1.1.1 ]
+        -
+            name: a_class
+            assert: "option[12].hex == 'hostname'"
+            options:
+                values:
+                    6:
+                        type: ip_list
+                        value: [ 1.1.1.1 ]
+        -
+            name: b_class
+            assert: "member('a_class') and pkt4.mac == 0xDEADBEEF"
+            options:
+                values:
+                    6:
+                        type: ip_list
+                        value: [ 1.1.1.1 ]
+        -
+            name: c_class
+            # circular
+            assert: "member('a_class') and member('b_class') or member('my_class')"
+            options:
+                values:
+                    6:
+                        type: ip_list
+                        value: [ 1.1.1.1 ]

--- a/libs/config/sample/config.yaml
+++ b/libs/config/sample/config.yaml
@@ -150,6 +150,22 @@ networks:
 client_classes:
     v4:
         -
+            name: c_class
+            assert: "member('a_class') and member('b_class')"
+            options:
+                values:
+                    6:
+                        type: ip_list
+                        value: [ 1.1.1.1 ]
+        -
+            name: d_class
+            assert: "member('b_class') and member('c_class')"
+            options:
+                values:
+                    6:
+                        type: ip_list
+                        value: [ 1.1.1.1 ]
+        -
           name: my_class
           assert: "pkt4.mac == 0xDEADBEEF"
           options:
@@ -173,19 +189,4 @@ client_classes:
                     6:
                         type: ip_list
                         value: [ 1.1.1.1 ]
-        -
-            name: c_class
-            assert: "member('a_class') and member('b_class')"
-            options:
-                values:
-                    6:
-                        type: ip_list
-                        value: [ 1.1.1.1 ]
-        -
-            name: d_class
-            assert: "member('b_class') and member('c_class')"
-            options:
-                values:
-                    6:
-                        type: ip_list
-                        value: [ 1.1.1.1 ]
+

--- a/libs/config/sample/config.yaml
+++ b/libs/config/sample/config.yaml
@@ -165,3 +165,27 @@ client_classes:
                     6:
                         type: ip_list
                         value: [ 1.1.1.1 ]
+        -
+            name: b_class
+            assert: "member('a_class') and pkt4.mac == 0xDEADBEEF"
+            options:
+                values:
+                    6:
+                        type: ip_list
+                        value: [ 1.1.1.1 ]
+        -
+            name: c_class
+            assert: "member('a_class') and member('b_class')"
+            options:
+                values:
+                    6:
+                        type: ip_list
+                        value: [ 1.1.1.1 ]
+        -
+            name: d_class
+            assert: "member('b_class') and member('c_class')"
+            options:
+                values:
+                    6:
+                        type: ip_list
+                        value: [ 1.1.1.1 ]

--- a/libs/config/src/client_classes.rs
+++ b/libs/config/src/client_classes.rs
@@ -71,7 +71,11 @@ impl ClientClasses {
             opts,
         };
         for class in &self.classes {
+            // eval class, passing args
             if class.eval(&args) {
+                // add class name to dependencies set, for future evals
+                // classes are always eval'd in topological order, so
+                // future evals know what prior evals were
                 args.deps.insert(class.name.to_owned());
             }
         }

--- a/libs/topo_sort/Cargo.toml
+++ b/libs/topo_sort/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "topo_sort"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+thiserror = { workspace = true }

--- a/libs/topo_sort/src/lib.rs
+++ b/libs/topo_sort/src/lib.rs
@@ -5,7 +5,7 @@
 //! nodes in the order of which they need to be evaluated.   Ex.
 //!
 //!   ```rust
-//! use dora_core::server::topo_sort::DependencyTree;
+//! use topo_sort::DependencyTree;
 //! use std::any::{Any, TypeId};
 //!
 //! struct A;
@@ -195,8 +195,8 @@ where
     /// Topologically sort the items in our adjecency map, producing a list of
     /// items in order they need be run according to their dependencies.
     /// Ex.
-    /// A -> B -> D
-    ///   -> C
+    /// A <- B <- D
+    /// A <- C
     /// output: [A, C, B, D] or [A, B, C, D]
     /// Will return Err if there is a cycle or if the map is malformed
     pub fn topological_sort(self) -> Result<Vec<T>, TopoSortError> {
@@ -379,7 +379,4 @@ mod tests {
             ]
         );
     }
-
-    #[test]
-    fn runtest() {}
 }


### PR DESCRIPTION
Adds the `member()` function to the client class expression allowing client class dependencies. On startup, dora parses the `client_class` section of the config and parses each `assert` into an AST that's held in memory. If the expression uses `member('classname')`, we will track that class as having a dependency on `classname`. We will then topologically sort the classes, so that we evaluate them in proper order. Circular dependencies will cause the config to fail to parse and dora will exit with an error.

Ex,
```
client_classes:
    v4:
        -
            name: a_class
            assert: "option[12].hex == 'hostname'"
            options:
                values:
                    6:
                        type: ip_list
                        value: [ 1.1.1.1 ]
        -
            name: b_class
            assert: "member('a_class') and pkt4.mac == 0xDEADBEEF"
            options:
                values:
                    6:
                        type: ip_list
                        value: [ 1.1.1.1 ]
        -
            name: c_class
            assert: "member('a_class') and member('b_class')"
            options:
                values:
                    6:
                        type: ip_list
                        value: [ 1.1.1.1 ]
```

`a_class` has no dependencies
`b_class` has a dependency on `a_class`
`c_class` has a dependency on `b_class` and `a_class`

When we parse the config, we will topo sort the classes such that they are evaluated in the order: `a_class`, `b_class`, `c_class`. The result of each evaluation is fed into the next eval, so the evaluator has the result from the previous dependencies.
