### PR TITLE
client class ifelse & hexstring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,6 +70,9 @@ name = "anyhow"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "async-io"
@@ -192,6 +210,21 @@ dependencies = [
  "rustversion",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
 ]
 
 [[package]]
@@ -1139,6 +1172,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1713,6 +1752,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1879,6 +1927,15 @@ checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
  "hermit-abi 0.1.19",
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.30.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2536,6 +2593,12 @@ dependencies = [
  "web-sys",
  "winapi",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a36c42d1873f9a77c53bde094f9664d9891bc604a45b4798fd2c389ed12e5b"
 
 [[package]]
 name = "rustc_version"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 # default-members = ["bin"]
 
 [workspace.dependencies]
-anyhow = "1.0"
+anyhow = { version = "1.0", features = ["backtrace"] }
 async-trait = "0.1"
 bytes = "1.1"
 clap = { version = "4.1.8", features = ["derive", "env"] }

--- a/example.yaml
+++ b/example.yaml
@@ -291,6 +291,10 @@ v6:
 #   ifelse(expr, expr_a, expr_b): if else control flow, first expression must evaluate to true/false
 #                       and if true expr_a will return else expr_b
 #
+#   hexstring(pkt4.mac, ':'): turns bytes into a string separated by the separator string
+#                       ex. hexstring(pkt4.mac, ':') == '66:6f:6f' 
+#                        (if pkt4.mac is '0x666f6f')
+#
 #   member('classname'): reference another class using the `member('my_class')` function. Dependency
 #                   cycles will fail to parse the config. 
 # 

--- a/example.yaml
+++ b/example.yaml
@@ -284,17 +284,40 @@ v6:
 #   pkt header:
 #       pkt4.mac: chaddr in DHCP message header (`pkt4.mac == 0xDEADBEEF`)
 #   
-#   substring(expr, i, j): substring function (`substring('foobar', 0, 3) == 'foo')
+#   substring(expr, start, len): substring function (`substring('foobar', 0, 3) == 'foo'`)
 #
-#   member('classname'): reference another class using the `member()` function. Dependency
+#   concat(expr, concat): concat function (`concat('foo', 'bar') == 'foobar')
+#
+#   ifelse(expr, expr_a, expr_b): if else control flow, first expression must evaluate to true/false
+#                       and if true expr_a will return else expr_b
+#
+#   member('classname'): reference another class using the `member('my_class')` function. Dependency
 #                   cycles will fail to parse the config. 
 # 
 # example:
 #
-#       substring(option[61].hex, 0, 3) == 'foo'
+#       `substring(option[61].hex, 0, 3) == 'foo'`
 # 
-
-
+#  Vendor classes:
+#
+#   To match on the standard option 60 vendor class identifier, use `option[60].hex` in your assertion.
+#   You can then specify options for the class providing option 43, for the encapsulated vendor options.
+#   example.
+#       name: my_vendor_class
+#       assert: "option[60].hex == 'MSFT5.0'"
+#       options:
+#           values:
+#              43:
+#                  type: sub_option
+#                  value:
+#                      1:
+#                          type: str
+#                          value: "foobar"
+#                      2:
+#                          type: ip
+#                          value: 1.2.3.4
+#
+#   Attaching `my_vendor_class` to a range/reservation will provide the defined opt 43 vendor options.
 client_classes:
     # only v4 supported at the moment
     v4:

--- a/libs/client-classification/benches/my_benchmark.rs
+++ b/libs/client-classification/benches/my_benchmark.rs
@@ -9,7 +9,7 @@ use pest::Parser;
 
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function(
-        "substring(mac, 0, 6) == '001122' && option[61].hex == 'some_client_id'",
+        "substring('foobar, 0, 6) == 'foo' && option[61].hex == 'some_client_id'",
         |b| {
             b.iter(|| {
                 let mut opts = HashMap::new();
@@ -18,11 +18,10 @@ fn criterion_benchmark(c: &mut Criterion) {
                     UnknownOption::new(61.into(), b"some_client_id".to_vec()),
                 );
 
-                let chaddr = "001122334455".to_owned();
-
+                let chaddr = &hex::decode("DEADBEEF").unwrap();
                 let tokens = ast::PredicateParser::parse(
                     ast::Rule::expr,
-                    "substring(pkt4.mac, 0, 6) == '001122' and option[61].hex == 'some_client_id'",
+                    "substring('foobar', 0, 3) == 'foo' and option[61].hex == 'some_client_id'",
                 )
                 .unwrap();
 
@@ -41,18 +40,18 @@ fn criterion_benchmark(c: &mut Criterion) {
         },
     );
     c.bench_function(
-        "just eval: substring(pkt4.mac, 0, 6) == '001122' && option[61].hex == 'some_client_id'",
+        "just eval: substring('foobar', 0, 6) == 'foo' && option[61].hex == 'some_client_id'",
         |b| {
             let tokens = ast::PredicateParser::parse(
                 ast::Rule::expr,
-                "substring(pkt4.mac, 0, 6) == '001122' and option[61].hex == 'some_client_id'",
+                "substring('foobar', 0, 6) == 'foo' and option[61].hex == 'some_client_id'",
             )
             .unwrap();
 
             let ast = client_classification::ast::build_ast(tokens).unwrap();
 
             b.iter(move || {
-                let chaddr = "001122334455".to_owned();
+                let chaddr = &hex::decode("DEADBEEF").unwrap();
                 let mut opts = HashMap::new();
                 opts.insert(
                     61.into(),

--- a/libs/client-classification/src/grammar.pest
+++ b/libs/client-classification/src/grammar.pest
@@ -43,6 +43,7 @@ pkt = _{
 
 substring = { "substring(" ~ expr ~ "," ~ integer ~ "," ~ integer ~ ")" }
 concat = { "concat(" ~ expr ~ "," ~ expr ~ ")" }
+ifelse = { "ifelse(" ~ expr ~ "," ~ expr ~ "," ~ expr ~ ")" }
 
 expr = { prefix* ~ primary ~ postfix* ~ (operation ~ prefix* ~ primary ~ postfix* )* }
 
@@ -54,7 +55,7 @@ postfix  =  _{ to_hex | exists | sub_opt }
     exists    =   { ".exists" } 
     sub_opt    =   { "." ~ option } 
 
-primary = _{ hex | ip | integer | string | boolean | option | relay | pkt | substring | concat | member | "(" ~ expr ~ ")" }
+primary = _{ hex | ip | integer | string | boolean | option | relay | pkt | substring | concat | ifelse | member | "(" ~ expr ~ ")" }
 predicate = _{ SOI ~ expr ~ EOI }
 
 WHITESPACE = _{ " " | "\t" | "\r" | "\n" }

--- a/libs/client-classification/src/grammar.pest
+++ b/libs/client-classification/src/grammar.pest
@@ -43,6 +43,7 @@ pkt = _{
 
 substring = { "substring(" ~ expr ~ "," ~ integer ~ "," ~ integer ~ ")" }
 concat = { "concat(" ~ expr ~ "," ~ expr ~ ")" }
+hexstring = { "hexstring(" ~ expr ~ "," ~ string ~ ")" }
 ifelse = { "ifelse(" ~ expr ~ "," ~ expr ~ "," ~ expr ~ ")" }
 
 expr = { prefix* ~ primary ~ postfix* ~ (operation ~ prefix* ~ primary ~ postfix* )* }
@@ -55,7 +56,7 @@ postfix  =  _{ to_hex | exists | sub_opt }
     exists    =   { ".exists" } 
     sub_opt    =   { "." ~ option } 
 
-primary = _{ hex | ip | integer | string | boolean | option | relay | pkt | substring | concat | ifelse | member | "(" ~ expr ~ ")" }
+primary = _{ hex | ip | integer | string | boolean | option | relay | pkt | substring | concat | ifelse | hexstring | member | "(" ~ expr ~ ")" }
 predicate = _{ SOI ~ expr ~ EOI }
 
 WHITESPACE = _{ " " | "\t" | "\r" | "\n" }

--- a/libs/client-classification/src/lib.rs
+++ b/libs/client-classification/src/lib.rs
@@ -667,7 +667,7 @@ mod tests {
     #[test]
     fn test_hexstring() {
         let args = Args {
-            chaddr: &hex::decode("DEADBEEF").unwrap(),
+            chaddr: &hex::decode(hex::encode("foo")).unwrap(),
             opts: HashMap::new(),
             msg: &v4::Message::default(),
             deps: HashSet::new(),
@@ -688,5 +688,10 @@ mod tests {
         let expr = ast::parse("hexstring(0xf01234,'..')").unwrap();
         let val = eval(&expr, &args).unwrap();
         assert_eq!(val, Val::String("f0..12..34".to_owned()));
+
+        let expr = ast::parse("hexstring(pkt4.mac,':')").unwrap();
+        let val = eval(&expr, &args).unwrap();
+        // foo -> 666f6f
+        assert_eq!(val, Val::String("66:6f:6f".to_owned()));
     }
 }

--- a/libs/client-classification/src/lib.rs
+++ b/libs/client-classification/src/lib.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
+    ops::{Range, RangeFrom, RangeTo},
     str,
 };
 
@@ -50,10 +51,10 @@ fn is_bool(val: Val) -> EvalResult<bool> {
         err => Err(EvalErr::ExpectedBool(err)),
     }
 }
-fn is_str(val: Val) -> EvalResult<String> {
+fn is_bytes(val: Val) -> EvalResult<Vec<u8>> {
     match val {
-        Val::String(s) => Ok(s),
-        err => Err(EvalErr::ExpectedString(err)),
+        Val::Bytes(s) => Ok(s),
+        err => Err(EvalErr::ExpectedBytes(err)),
     }
 }
 fn is_int(val: Val) -> EvalResult<u32> {
@@ -118,7 +119,7 @@ pub fn get_class_dependencies(expr: &Expr) -> Vec<String> {
 }
 
 pub struct Args<'a> {
-    pub chaddr: String,
+    pub chaddr: &'a [u8],
     pub opts: HashMap<v4::OptionCode, v4::UnknownOption>,
     pub msg: &'a v4::Message,
     pub deps: HashSet<String>,
@@ -130,9 +131,9 @@ pub fn eval(expr: &Expr, args: &Args) -> Result<Val, EvalErr> {
     use Expr::*;
     Ok(match expr {
         Bool(b) => Val::Bool(*b),
-        String(s) => Val::String(s.to_lowercase()),
+        String(s) => Val::String(s.clone()),
         Int(i) => Val::Int(*i),
-        Hex(h) => Val::String(h.to_lowercase()),
+        Hex(h) => Val::Bytes(h.to_vec()),
         Relay(o) => match args
             .opts
             .get(&v4::OptionCode::RelayAgentInformation)
@@ -146,7 +147,7 @@ pub fn eval(expr: &Expr, args: &Args) -> Result<Val, EvalErr> {
             None => Val::Empty,
         },
         // TODO: can probably use msg.chaddr() instead of an explicit param here
-        Mac() => Val::String(args.chaddr.to_lowercase()),
+        Mac() => Val::Bytes(args.chaddr.to_vec()),
         Hlen() => Val::Int(args.msg.hlen() as u32),
         HType() => Val::Int(u8::from(args.msg.htype()) as u32),
         CiAddr() => Val::Int(u32::from(args.msg.ciaddr())),
@@ -185,10 +186,11 @@ pub fn eval(expr: &Expr, args: &Args) -> Result<Val, EvalErr> {
         Or(lhs, rhs) => Val::Bool(is_bool(eval(lhs, args)?)? || is_bool(eval(rhs, args)?)?),
         Equal(lhs, rhs) => Val::Bool(eval_bool(lhs, rhs, args)?),
         NEqual(lhs, rhs) => Val::Bool(!eval_bool(lhs, rhs, args)?),
-        Substring(lhs, start, len) => {
-            // TODO: add case for Val::Bytes
-            Val::String(substring(&is_str(eval(lhs, args)?)?, *start, *len))
-        }
+        Substring(lhs, start, len) => match eval(lhs, args)? {
+            Val::Bytes(b) => Val::Bytes(slice(b, *start, *len)),
+            Val::String(s) => Val::String(substring(&s, *start, *len)),
+            err => return Err(EvalErr::ExpectedString(err)),
+        },
         Concat(lhs, rhs) => match (eval(lhs, args)?, eval(rhs, args)?) {
             (Val::String(mut a), Val::String(b)) => {
                 a.push_str(&b);
@@ -215,27 +217,63 @@ pub fn eval(expr: &Expr, args: &Args) -> Result<Val, EvalErr> {
                 eval(b, args)?
             }
         }
+        Hexstring(expr, sep) => Val::String(
+            hex::encode(is_bytes(eval(expr, args)?)?)
+                .as_bytes()
+                .chunks_exact(2)
+                .map(std::str::from_utf8)
+                .collect::<Result<Vec<_>, _>>()?
+                .join(sep),
+        ),
         Member(s) => Val::Bool(args.deps.contains(s)),
     })
 }
 
-fn substring(s: &str, mut start: isize, j: Option<isize>) -> String {
-    if start.unsigned_abs() >= s.len() {
-        return String::default();
+fn substring(s: &str, start: isize, j: Option<isize>) -> String {
+    match get_pos(s.len(), start, j) {
+        None => String::default(),
+        Some(SliceSubstr::To(r)) => s[r].to_owned(),
+        Some(SliceSubstr::From(r)) => s[r].to_owned(),
+        Some(SliceSubstr::Slice(r)) => s[r].to_owned(),
+    }
+}
+
+fn slice<T>(s: T, start: isize, j: Option<isize>) -> Vec<u8>
+where
+    T: AsRef<[u8]>,
+{
+    let s = s.as_ref();
+    match get_pos(s.len(), start, j) {
+        None => Vec::default(),
+        Some(SliceSubstr::To(r)) => s[r].to_owned(),
+        Some(SliceSubstr::From(r)) => s[r].to_owned(),
+        Some(SliceSubstr::Slice(r)) => s[r].to_owned(),
+    }
+}
+
+enum SliceSubstr {
+    To(RangeTo<usize>),
+    From(RangeFrom<usize>),
+    Slice(Range<usize>),
+}
+
+fn get_pos(s_len: usize, mut start: isize, j: Option<isize>) -> Option<SliceSubstr> {
+    if start.unsigned_abs() >= s_len {
+        return None;
     }
     let mut neg = false;
     if start.is_negative() {
         // start is neg
         neg = true;
-        start += s.len() as isize;
+        start += s_len as isize;
     }
 
     match j {
         None => {
             if neg {
-                s[..start.unsigned_abs()].to_owned()
+                Some(SliceSubstr::To(..start.unsigned_abs()))
             } else {
-                s[start.unsigned_abs()..].to_owned()
+                Some(SliceSubstr::From(start.unsigned_abs()..))
             }
         }
         Some(mut len) => {
@@ -248,10 +286,12 @@ fn substring(s: &str, mut start: isize, j: Option<isize>) -> String {
                     start = 0;
                 }
             }
-            if start + len > s.len() as isize {
-                len = len.clamp(0, s.len() as isize - start);
+            if start + len > s_len as isize {
+                len = len.clamp(0, s_len as isize - start);
             }
-            s[start.unsigned_abs()..(start.unsigned_abs() + len.unsigned_abs())].to_owned()
+            Some(SliceSubstr::Slice(
+                start.unsigned_abs()..(start.unsigned_abs() + len.unsigned_abs()),
+            ))
         }
     }
 }
@@ -287,7 +327,7 @@ mod tests {
     fn test_opt_exists() {
         let tokens = PredicateParser::parse(Rule::expr, "not option[123].exists").unwrap();
         let args = Args {
-            chaddr: "001122334455".to_owned(),
+            chaddr: "001122334455".as_bytes(),
             opts: HashMap::new(),
             msg: &v4::Message::default(),
             deps: HashSet::new(),
@@ -300,12 +340,24 @@ mod tests {
     fn test_ip_parser() {
         let tokens = PredicateParser::parse(Rule::expr, "100.10.10.10 == 100.10.10.10").unwrap();
         let args = Args {
-            chaddr: "001122334455".to_owned(),
+            chaddr: "001122334455".as_bytes(),
             opts: HashMap::new(),
             msg: &v4::Message::default(),
             deps: HashSet::new(),
         };
         let val = eval(&build_ast(tokens).unwrap(), &args).unwrap();
+        assert_eq!(val, Val::Bool(true));
+    }
+    #[test]
+    fn test_mac() {
+        let args = Args {
+            chaddr: &hex::decode("010203040506").unwrap(),
+            opts: HashMap::new(),
+            msg: &v4::Message::default(),
+            deps: HashSet::new(),
+        };
+        let expr = ast::parse("pkt4.mac == 0x010203040506").unwrap();
+        let val = eval(&expr, &args).unwrap();
         assert_eq!(val, Val::Bool(true));
     }
 
@@ -317,12 +369,11 @@ mod tests {
             UnknownOption::new(61.into(), b"some_client_id".to_vec()),
         );
 
-        let tokens = ast::parse(
-            "substring(pkt4.mac, 0, 6) == '001122' and option[61].hex == 'some_client_id'",
-        )
-        .unwrap();
+        let tokens =
+            ast::parse("substring('foobar', 0, 3) == 'foo' and option[61].hex == 'some_client_id'")
+                .unwrap();
         let args = Args {
-            chaddr: "001122334455".to_owned(),
+            chaddr: &hex::decode("DEADBEEF").unwrap(),
             opts,
             msg: &v4::Message::default(),
             deps: HashSet::new(),
@@ -350,7 +401,7 @@ mod tests {
             UnknownOption::new(v4::OptionCode::RelayAgentInformation, data),
         );
         let args = Args {
-            chaddr: "001122334455".to_owned(),
+            chaddr: &hex::decode("DEADBEEF").unwrap(),
             opts,
             msg: &v4::Message::default(),
             deps: HashSet::new(),
@@ -384,7 +435,7 @@ mod tests {
             UnknownOption::new(v4::OptionCode::RelayAgentInformation, data),
         );
         let args = Args {
-            chaddr: "001122334455".to_owned(),
+            chaddr: &hex::decode("DEADBEEF").unwrap(),
             opts,
             msg: &v4::Message::default(),
             deps: HashSet::new(),
@@ -397,6 +448,11 @@ mod tests {
         let expr = ast::parse("option[82].option[23].hex").unwrap();
         let val = eval(&expr, &args).unwrap();
         assert_eq!(val, Val::Bytes(vec![1, 2, 3]));
+
+        let r = hex::encode([1, 2, 3]);
+        let expr = ast::parse(format!("option[82].option[23].hex == 0x{r}")).unwrap();
+        let val = eval(&expr, &args).unwrap();
+        assert_eq!(val, Val::Bool(true));
 
         let expr = ast::parse("option[82].option[23].exists").unwrap();
         let val = eval(&expr, &args).unwrap();
@@ -447,13 +503,14 @@ mod tests {
             Ipv4Addr::new(4, 4, 4, 4),
             "123456".as_bytes(),
         );
-        msg.set_htype(v4::HType::Eth);
-        let mut opts = v4::DhcpOptions::new();
-        opts.insert(v4::DhcpOption::MessageType(v4::MessageType::Offer));
-        msg.set_opts(opts);
+        msg.set_xid(1234).set_htype(v4::HType::Eth).set_opts({
+            let mut opts = v4::DhcpOptions::new();
+            opts.insert(v4::DhcpOption::MessageType(v4::MessageType::Offer));
+            opts
+        });
 
         let args = Args {
-            chaddr: "001122334455".to_owned(),
+            chaddr: &hex::decode("DEADBEEF").unwrap(),
             opts: options,
             msg: &msg,
             deps: HashSet::new(),
@@ -475,6 +532,10 @@ mod tests {
         assert_eq!(val, Val::Bool(true));
 
         let expr = ast::parse("pkt4.msgtype == 2").unwrap();
+        let val = eval(&expr, &args).unwrap();
+        assert_eq!(val, Val::Bool(true));
+
+        let expr = ast::parse("pkt4.transid == 1234").unwrap();
         let val = eval(&expr, &args).unwrap();
         assert_eq!(val, Val::Bool(true));
     }
@@ -510,7 +571,7 @@ mod tests {
         );
 
         let args = Args {
-            chaddr: "001122334455".to_owned(),
+            chaddr: &hex::decode("DEADBEEF").unwrap(),
             opts: opts.clone(),
             msg: &msg,
             deps: ["foobar", "bazz", "bingo", "bongo"]
@@ -523,7 +584,7 @@ mod tests {
 
         // remove one member from `or`, should eval to true still
         let args = Args {
-            chaddr: "001122334455".to_owned(),
+            chaddr: &hex::decode("DEADBEEF").unwrap(),
             opts: opts.clone(),
             msg: &msg,
             deps: ["foobar", "bazz", "bingo"]
@@ -536,7 +597,7 @@ mod tests {
 
         // remove one of members so eval == false
         let args = Args {
-            chaddr: "001122334455".to_owned(),
+            chaddr: &hex::decode("DEADBEEF").unwrap(),
             opts,
             msg: &msg,
             deps: ["foobar", "bingo"]
@@ -566,7 +627,7 @@ mod tests {
     #[test]
     fn test_concat() {
         let args = Args {
-            chaddr: "001122334455".to_owned(),
+            chaddr: &hex::decode("DEADBEEF").unwrap(),
             opts: HashMap::new(),
             msg: &v4::Message::default(),
             deps: HashSet::new(),
@@ -580,7 +641,7 @@ mod tests {
     #[test]
     fn test_ifelse() {
         let args = Args {
-            chaddr: "001122334455".to_owned(),
+            chaddr: &hex::decode("DEADBEEF").unwrap(),
             opts: HashMap::new(),
             msg: &v4::Message::default(),
             deps: HashSet::new(),
@@ -601,5 +662,31 @@ mod tests {
         let expr = ast::parse("ifelse((not option[123].exists), option[1].exists, 'bar')").unwrap();
         let val = eval(&expr, &args).unwrap();
         assert_eq!(val, Val::Bool(false));
+    }
+
+    #[test]
+    fn test_hexstring() {
+        let args = Args {
+            chaddr: &hex::decode("DEADBEEF").unwrap(),
+            opts: HashMap::new(),
+            msg: &v4::Message::default(),
+            deps: HashSet::new(),
+        };
+
+        let expr = ast::parse("hexstring(0x1234,':')").unwrap();
+        let val = eval(&expr, &args).unwrap();
+        assert_eq!(val, Val::String("12:34".to_owned()));
+
+        let expr = ast::parse("hexstring(0x56789a,'-')").unwrap();
+        let val = eval(&expr, &args).unwrap();
+        assert_eq!(val, Val::String("56-78-9a".to_owned()));
+
+        let expr = ast::parse("hexstring(0xbcde,'')").unwrap();
+        let val = eval(&expr, &args).unwrap();
+        assert_eq!(val, Val::String("bcde".to_owned()));
+
+        let expr = ast::parse("hexstring(0xf01234,'..')").unwrap();
+        let val = eval(&expr, &args).unwrap();
+        assert_eq!(val, Val::String("f0..12..34".to_owned()));
     }
 }

--- a/libs/config/src/client_classes.rs
+++ b/libs/config/src/client_classes.rs
@@ -121,11 +121,11 @@ impl ClientClass {
 
 fn to_unknown_opts(
     req: &dhcproto::v4::Message,
-) -> Result<(String, HashMap<OptionCode, UnknownOption>)> {
+) -> Result<(&[u8], HashMap<OptionCode, UnknownOption>)> {
     // TODO: find a better way to do this so we don't have to convert to Unknown on every eval
     // possibly, add better methods to dhcproto so we can pull the data section out?
     Ok((
-        hex::encode(req.chaddr()),
+        req.chaddr(),
         req.opts()
             .iter()
             .map(|(k, v)| {


### PR DESCRIPTION
Add `ifelse` branching and `hexstring`
```
ifelse(cond, a, b): if else control flow, first expression must evaluate to true/false
                       and if true, return expression a else expression b

hexstring(pkt4.mac, ':'): turns bytes into a string separated by the separator char/string
                      ex. hexstring(pkt4.mac, ':') == '66:6f:6f' 
                      ex. hexstring(pkt4.mac, '..') == '66..6f..6f' 
                      (if pkt4.mac is '0x666f6f')
```

Also fixes some issues with the `pkt4.mac` representation, which used to be a hex encoded string and is now a `Vec<u8>`