### PR TITLE
accept list types implicitly in options config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,6 +511,7 @@ dependencies = [
  "dora-core",
  "hex",
  "ipnet",
+ "phf",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2087,6 +2088,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928c6535de93548188ef63bb7c4036bd415cd8f36ad25af44b9789b2ee72a48c"
 dependencies = [
+ "phf_macros",
  "phf_shared",
 ]
 
@@ -2108,6 +2110,19 @@ checksum = "b1181c94580fa345f50f19d738aaa39c0ed30a600d95cb2d3e23f94266f14fbf"
 dependencies = [
  "phf_shared",
  "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92aacdc5f16768709a569e913f7451034034178b05bdc8acda226659a3dccc66"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/bin/tests/test_configs/basic.yaml
+++ b/bin/tests/test_configs/basic.yaml
@@ -20,7 +20,7 @@ networks:
                             type: ip
                             value: 192.168.1.1
                         3:
-                            type: ip_list
+                            type: ip
                             value:
                                 - 192.168.1.1
 
@@ -41,7 +41,7 @@ networks:
                             type: ip
                             value: 192.168.2.1
                         3:
-                            type: ip_list
+                            type: ip
                             value:
                                 - 192.168.2.1
                         40:
@@ -68,7 +68,7 @@ networks:
                             type: ip
                             value: 192.168.2.1
                         3:
-                            type: ip_list
+                            type: ip
                             value:
                                 - 192.168.2.1
                 match:
@@ -90,7 +90,7 @@ networks:
                             type: ip
                             value: 10.10.0.1
                         3:
-                            type: ip_list
+                            type: ip
                             value:
                                 - 10.10.0.1
                 match:
@@ -106,7 +106,7 @@ networks:
                             type: ip
                             value: 10.10.0.1
                         3:
-                            type: ip_list
+                            type: ip
                             value:
                                 - 10.10.0.1
                 match:
@@ -127,7 +127,7 @@ networks:
                             type: ip
                             value: 10.10.0.1
                         3:
-                            type: ip_list
+                            type: ip
                             value:
                                 - 10.10.0.1
                 except:

--- a/bin/tests/test_configs/classes.yaml
+++ b/bin/tests/test_configs/classes.yaml
@@ -1,0 +1,36 @@
+interfaces: 
+    - dhcpsrv
+networks:
+    192.168.2.0/24:
+        probation_period: 86400
+        ranges:
+            -
+                class: testclass
+                start: 192.168.2.100
+                end: 192.168.2.103
+                config:
+                    lease_time:
+                        default: 3600
+                options:
+                    values:
+                        subnet_mask:
+                            type: ip
+                            value: 192.168.1.1
+                        routers:
+                            type: ip
+                            value: [ 192.168.1.1 ]
+                        domain_name_servers:
+                            type: ip
+                            value: [ 1.1.1.1 ]
+
+client_classes:  
+    v4:
+        -
+            name: testclass
+            assert: "substring(option[60].hex, 0, 7) == 'android'"
+            options:
+                values:
+                    vendor_extensions:
+                        type: u32
+                        value: [1, 2, 3, 4]
+

--- a/docs/pi_setup.md
+++ b/docs/pi_setup.md
@@ -59,11 +59,11 @@ edit `/etc/dhcpcd.conf` and append:
 ```
 interface wlan0
 # pick some static IP, this is the subnet we'll serve dora on
-static ip_address=192.168.5.1/24 
+static ip_address=192.168.5.1/24
 nohook wpa_supplicant
 ```
 
-### 3. Set up IP forwarding to eth0  
+### 3. Set up IP forwarding to eth0
 
 edit `/etc/sysctl.d/99-sysctl.conf` and either ensure the following lines are uncommented or append them:
 
@@ -72,7 +72,7 @@ net.ipv4.ip_forward=1
 net.ipv6.conf.all.forwarding=1
 ```
 
-***Note***: You may also find it useful here to create `/etc/sysctl.d/routed-ap.conf` and set its contents to:
+**_Note_**: You may also find it useful here to create `/etc/sysctl.d/routed-ap.conf` and set its contents to:
 
 ```
 # Enable IPv4 routing
@@ -85,7 +85,7 @@ then reboot the Pi to ensure the configuration settings are properly applied:
 sudo reboot
 ```
 
-once the Pi has rebooted, SSH back in and execute: 
+once the Pi has rebooted, SSH back in and execute:
 
 ```bash
 sudo iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
@@ -101,8 +101,8 @@ sudo netfilter-persistent save
 A very simple config (IPv4 only) that matches how this guide has configured hostapd might look like:
 
 ```yaml
-interfaces: 
-  - wlan0
+interfaces:
+    - wlan0
 networks:
     192.168.5.0/24:
         probation_period: 86400
@@ -121,16 +121,16 @@ networks:
                           type: ip
                           value: 255.255.255.0
                       3: # router (if not specified, will come from `interfaces`)
-                          type: ip_list
+                          type: ip
                           value:
                               - 192.168.5.1
                       6: # domain name (if running a DNS server like dnsmasq also, use its IP)
-                          type: ip_list
+                          type: ip
                           value:
                               - 8.8.8.8
                       28: # broadcast addr (if not specified, comes from `interfaces`)
-                         type: ip
-                         value: 192.168.5.255
+                          type: ip
+                          value: 192.168.5.255
 ```
 
 You may wish to save this minimal config to `pi.yaml` to try it out, or see [example.yaml](../example.yaml) for the full set of options. You can also use `dora --help` to see arguments.

--- a/example.yaml
+++ b/example.yaml
@@ -72,15 +72,15 @@ networks:
                 # to respond to any parameter request list values.
                 options:
                     values:
-                        # each option has a `type`/`value`. valid types are:
-                        #   ip          ex. 1.2.3.4
-                        #   ip_list     ex. [1.2.3.4, 1.2.3.4]
-                        #   domain_list (encodes list of domains in compressed DNS format) ex. ["foobar.com.", "apple.marketing.com."]
+                        # each option has a `type`/`value`. the 'value' field can implicitly be a list for (all types except b64/hex/sub_option).
+                        # valid types are:
+                        #   ip          ex. 1.2.3.4 or [1.2.3.4, 1.2.3.4]
+                        #   domain      (encodes list of domains in compressed DNS format) ex. ["foobar.com.", "apple.marketing.com."] or a single domain ex. "foobar.com."
                         #   str         ex. "foobar"
-                        #   u8
-                        #   u16
-                        #   u32
-                        #   i32
+                        #   u8          ex. 1 or [1, 2, 3]
+                        #   u16         ex. 1 or [1, 2, 3]
+                        #   u32         ex. 1 or [1, 2, 3]
+                        #   i32         ex. -1 or [-1, 2, 3]
                         #   b64         ex. "Zm9vYmFy"
                         #   hex         ex. "DEADBEEF"
                         #   sub_option
@@ -99,11 +99,11 @@ networks:
                             type: ip
                             value: 255.255.255.0
                         3: # router (if not specified, will come from `interfaces`)
-                            type: ip_list
+                            type: ip
                             value:
                                 - 192.168.5.1
                         6: # domain name (if running a DNS server like dnsmasq also, use its IP)
-                            type: ip_list
+                            type: ip
                             value:
                                 - 8.8.8.8
                         28: # broadcast addr (if not specified, comes from `interfaces`)
@@ -129,11 +129,11 @@ networks:
                             type: ip
                             value: 255.255.255.0
                         3:
-                            type: ip_list
+                            type: ip
                             value:
                                 - 192.168.5.1
                         6:
-                            type: ip_list
+                            type: ip
                             value:
                                 - 8.8.8.8
                         28:
@@ -341,6 +341,6 @@ client_classes:
           options: 
                 values: 
                     6:
-                        type: ip_list
+                        type: ip
                         value: [ 1.1.1.1 ]
           

--- a/example.yaml
+++ b/example.yaml
@@ -86,8 +86,15 @@ networks:
                         #   sub_option
                         # Look at: https://docs.rs/dhcproto/latest/dhcproto/v4/enum.DhcpOption.html for a list of opts and their type.
                         #
-                        # In the future, we could support a nicer way to handwrite 
-                        # these options, perhaps matching a string name to the opt code and type. 
+                        # For specifying options, use the number code or the name, for example
+                        #   1:
+                        #       type: ip
+                        #       value: 255.255.255.0
+                        # is equivalent to
+                        #   subnet_mask:
+                        #       type: ip
+                        #       value: 255.255.255.0
+                        # only some options have support for the string name identifier. 
                         1: # subnet mask (if not specified, comes from `interfaces`)
                             type: ip
                             value: 255.255.255.0

--- a/example.yaml
+++ b/example.yaml
@@ -72,11 +72,11 @@ networks:
                 # to respond to any parameter request list values.
                 options:
                     values:
-                        # each option has a `type`/`value`. the 'value' field can implicitly be a list for (all types except b64/hex/sub_option).
+                        # each option has a `type`/`value`. the 'value' field can implicitly be a list (all types except b64/hex/sub_option).
                         # valid types are:
                         #   ip          ex. 1.2.3.4 or [1.2.3.4, 1.2.3.4]
                         #   domain      (encodes list of domains in compressed DNS format) ex. ["foobar.com.", "apple.marketing.com."] or a single domain ex. "foobar.com."
-                        #   str         ex. "foobar"
+                        #   str         ex. "foobar" or ["foo", "bar"] 
                         #   u8          ex. 1 or [1, 2, 3]
                         #   u16         ex. 1 or [1, 2, 3]
                         #   u32         ex. 1 or [1, 2, 3]
@@ -84,7 +84,7 @@ networks:
                         #   b64         ex. "Zm9vYmFy"
                         #   hex         ex. "DEADBEEF"
                         #   sub_option
-                        # Look at: https://docs.rs/dhcproto/latest/dhcproto/v4/enum.DhcpOption.html for a list of opts and their type.
+                        # Look at: https://docs.rs/dhcproto/latest/dhcproto/v4/enum.DhcpOption.html for available opts and their corresponding type.
                         #
                         # For specifying options, use the number code or the name, for example
                         #   1:
@@ -169,7 +169,7 @@ networks:
     #     server_id: 192.168.0.1
 #
 # DHCPv6 
-# v6 support is largely unfinished at the moment. There is some early support for 
+# v6 support is largely experimental and unfinished. There is some early support for 
 # responding to INFOREQ.
 v6:
     # optional, interfaces to bind

--- a/libs/config/Cargo.toml
+++ b/libs/config/Cargo.toml
@@ -16,6 +16,7 @@ serde = { workspace = true }
 trust-dns-proto = { workspace = true }
 base64 = "0.21.0"
 hex = "0.4"
+phf = { version = "0.11", features = ["macros"] }
 
 dora-core = { path = "../../dora-core" }
 client-classification = { path = "../client-classification" }

--- a/libs/config/sample/circular_deps.yaml
+++ b/libs/config/sample/circular_deps.yaml
@@ -9,7 +9,7 @@ client_classes:
           options:
                 values:
                     6:
-                        type: ip_list
+                        type: ip
                         value: [ 1.1.1.1 ]
         -
             name: a_class
@@ -17,7 +17,7 @@ client_classes:
             options:
                 values:
                     6:
-                        type: ip_list
+                        type: ip
                         value: [ 1.1.1.1 ]
         -
             name: b_class
@@ -25,7 +25,7 @@ client_classes:
             options:
                 values:
                     6:
-                        type: ip_list
+                        type: ip
                         value: [ 1.1.1.1 ]
         -
             name: c_class
@@ -34,5 +34,5 @@ client_classes:
             options:
                 values:
                     6:
-                        type: ip_list
+                        type: ip
                         value: [ 1.1.1.1 ]

--- a/libs/config/sample/config.yaml
+++ b/libs/config/sample/config.yaml
@@ -20,7 +20,7 @@ networks:
                             type: ip
                             value: 192.168.1.1
                         3:
-                            type: ip_list
+                            type: ip
                             value:
                                 - 192.168.1.1
                         43:
@@ -50,7 +50,7 @@ networks:
                             type: ip
                             value: 192.168.0.1
                         3:
-                            type: ip_list
+                            type: ip
                             value:
                                 - 192.168.0.1
                         40:
@@ -77,7 +77,7 @@ networks:
                             type: ip
                             value: 192.168.0.1
                         routers:
-                            type: ip_list
+                            type: ip_list # for backwards compat testing
                             value:
                                 - 192.168.0.1
                         vendor_extensions:
@@ -108,7 +108,7 @@ networks:
                             type: ip
                             value: 10.10.0.1
                         3:
-                            type: ip_list
+                            type: ip
                             value:
                                 - 10.10.0.1
                 match:
@@ -128,7 +128,7 @@ networks:
                             type: ip
                             value: 10.0.0.1
                         3:
-                            type: ip_list
+                            type: ip
                             value:
                                 - 10.0.0.1
             -
@@ -144,7 +144,7 @@ networks:
                             type: ip
                             value: 10.0.1.1
                         3:
-                            type: ip_list
+                            type: ip
                             value:
                                 - 10.0.1.1
 client_classes:
@@ -155,7 +155,7 @@ client_classes:
             options:
                 values:
                     6:
-                        type: ip_list
+                        type: ip
                         value: [ 1.1.1.1 ]
         -
             name: d_class
@@ -163,7 +163,7 @@ client_classes:
             options:
                 values:
                     6:
-                        type: ip_list
+                        type: ip
                         value: [ 1.1.1.1 ]
         -
           name: my_class
@@ -171,7 +171,7 @@ client_classes:
           options:
                 values:
                     6:
-                        type: ip_list
+                        type: ip
                         value: [ 1.1.1.1 ]
         -
             name: a_class
@@ -179,7 +179,7 @@ client_classes:
             options:
                 values:
                     6:
-                        type: ip_list
+                        type: ip
                         value: [ 1.1.1.1 ]
         -
             name: b_class
@@ -187,6 +187,6 @@ client_classes:
             options:
                 values:
                     6:
-                        type: ip_list
+                        type: ip
                         value: [ 1.1.1.1 ]
 

--- a/libs/config/sample/config.yaml
+++ b/libs/config/sample/config.yaml
@@ -73,14 +73,14 @@ networks:
                         max: 4800
                 options:
                     values:
-                        1:
+                        subnet_mask:
                             type: ip
                             value: 192.168.0.1
-                        3:
+                        routers:
                             type: ip_list
                             value:
                                 - 192.168.0.1
-                        43:
+                        vendor_extensions:
                             type: sub_option
                             value:
                                 1:

--- a/libs/config/sample/long_opts.yaml
+++ b/libs/config/sample/long_opts.yaml
@@ -20,7 +20,7 @@ networks:
                             type: ip
                             value: 192.168.1.1
                         3:
-                            type: ip_list
+                            type: ip
                             value:
                                 - 192.168.1.1
                                 - 192.168.1.1
@@ -84,7 +84,7 @@ networks:
                                     type: ip
                                     value: 1.2.3.4
                                 3:
-                                    type: ip_list
+                                    type: ip
                                     value:
                                     - 192.168.1.1
                                     - 192.168.1.1

--- a/libs/config/src/client_classes.rs
+++ b/libs/config/src/client_classes.rs
@@ -107,12 +107,12 @@ impl ClientClasses {
 
 impl ClientClass {
     pub fn eval(&self, args: &Args) -> bool {
-        trace!(expr = ?self.assert, chaddr = ?args.chaddr, "evaluating expression");
+        trace!(name = ?self.name, expr = ?self.assert, chaddr = ?args.chaddr, "evaluating expression");
         match client_classification::eval(&self.assert, args) {
             Ok(Val::Bool(true)) => true,
             Ok(Val::Bool(false)) => false,
             res => {
-                error!(?res, class_name = ?self.name, "didn't evaluate to true/false");
+                error!(name = ?self.name, ?res, "expression didn't evaluate to true/false");
                 false
             }
         }

--- a/libs/config/src/wire/mod.rs
+++ b/libs/config/src/wire/mod.rs
@@ -64,3 +64,26 @@ impl From<MinMax> for LeaseTime {
         LeaseTime { default, min, max }
     }
 }
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+pub(crate) enum MaybeList<T> {
+    Val(T),
+    List(Vec<T>),
+}
+
+#[cfg(test)]
+mod tests {
+
+    pub static EXAMPLE: &str = include_str!("../../../../example.yaml");
+
+    // test we can encode/decode example file
+    #[test]
+    fn test_example() {
+        let cfg: crate::wire::Config = serde_yaml::from_str(EXAMPLE).unwrap();
+        println!("{cfg:#?}");
+        // back to the yaml
+        let s = serde_yaml::to_string(&cfg).unwrap();
+        println!("{s}");
+    }
+}

--- a/libs/config/src/wire/v4.rs
+++ b/libs/config/src/wire/v4.rs
@@ -58,7 +58,7 @@ use trust_dns_proto::{
     serialize::binary::{BinEncodable, BinEncoder},
 };
 
-use crate::wire::MinMax;
+use crate::wire::{MaybeList, MinMax};
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct Net {
@@ -144,13 +144,6 @@ pub enum Condition {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Opts(pub DhcpOptions);
-
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(untagged)]
-enum MaybeList<T> {
-    Val(T),
-    List(Vec<T>),
-}
 
 /// this type is only used as an intermediate representation
 /// Opts are received as essentially a HashMap<u8, Opt>

--- a/libs/config/src/wire/v4.rs
+++ b/libs/config/src/wire/v4.rs
@@ -197,10 +197,17 @@ impl<'de> serde::Deserialize<'de> for Opts {
             "all_subnets_local" => 27,
             "broadcast_addr" => 28,
             "static_routing_table" => 33,
+            "arp_cache_timeout" => 35,
+            "default_tcp_ttl" => 37,
+            "nis_domain" => 40,
+            "nis_servers" => 41,
+            "ntp_servers" => 42,
             "vendor_extensions" => 43,
+            "netbios_name_servers" => 44,
             "domain_search" => 119,
         };
 
+        // inner key type to handle string name or number
         #[derive(Serialize, Debug, PartialEq, Eq, Hash)]
         struct OptKey(u8);
         impl<'de> serde::Deserialize<'de> for OptKey {


### PR DESCRIPTION
This PR makes several quality of life changes to the config format. Firstly, some well-known keys can be replaced by their string versions in the config file:

```
                options:
                    values:
                        subnet_mask:
                            type: ip
                            value: 192.168.0.1
                        routers:
                            type: ip
                            value: [ 192.168.0.1 ]
                        vendor_extensions:
                            type: sub_option
                            value:
                                1:
                                    type: str
                                    value: "foobar"
                                2:
                                    type: ip
                                    value: 1.2.3.4
```

The full list of strings is in `libs/config/src/wire/v4.rs`

```
        static NAME_MAP: phf::Map<&'static str, u8> = phf::phf_map! {
            "subnet_mask" => 1,
            "time_offset" => 2,
            "routers" => 3,
            "time_servers" => 4,
            "name_servers" => 5,
            "domain_name_servers" => 6,
            "log_servers" => 7,
            "quote_servers" => 8,
            "lpr_servers" => 9,
            "impress_servers" => 10,
            "resource_location_servers" => 11,
            "hostname" => 12,
            "boot_size" => 13,
            "merit_dump" => 14,
            "domain_name" => 15,
            "swap_server" => 16,
            "root_path" => 17,
            "extensions_path" => 18,
            "ip_forwarding" => 19,
            "non_local_source_routing" => 20,
            "default_ip_ttl" => 23,
            "interface_mtu" => 26,
            "all_subnets_local" => 27,
            "broadcast_addr" => 28,
            "static_routing_table" => 33,
            "arp_cache_timeout" => 35,
            "default_tcp_ttl" => 37,
            "nis_domain" => 40,
            "nis_servers" => 41,
            "ntp_servers" => 42,
            "vendor_extensions" => 43,
            "netbios_name_servers" => 44,
            "domain_search" => 119,
        };
```

The second change is that `ip` and `ip_list` are no longer two distinct types. Instead, all types except b64/hex/sub_option now accept lists as well as single values. The type still needs to be one or the other, but now we can accept lists of `u8`/`u32`/`i32`/`domain`/`u16`/`bool` 

ex.
```
type: u16
value: [ 1, 2 ]
```
Will encode a` Vec<u16>` into that options data. Alternatively, you can use

```
type: u16,
value: 1
```

To insert a regular `u16` into the options data.


And just as before, dora will decode the equivalent json as well as yaml format for the config. yaml is presented here for readability.