### PR TITLE
dynamic bootp + rapid commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ It will pretty-print the internal dora config representation as well as parse th
 -   [v4 RFC3011](https://datatracker.ietf.org/doc/html/rfc3011)
 -   [v4 RFC3527](https://datatracker.ietf.org/doc/html/rfc3527)
 -   [v4 RFC4578](https://datatracker.ietf.org/doc/html/rfc4578)
+-   [v4 RFC4093](https://datatracker.ietf.org/doc/html/rfc4093)
 -   [v4 RFC6842](https://datatracker.ietf.org/doc/html/rfc6842)
 -   [v4 RFC3046](https://datatracker.ietf.org/doc/html/rfc3046)
 -   see [dhcproto](https://github.com/bluecatengineering/dhcproto) for protocol level support

--- a/bin/tests/basic.rs
+++ b/bin/tests/basic.rs
@@ -63,6 +63,41 @@ fn test_basic_dhcpv4_unicast() -> Result<()> {
     Ok(())
 }
 
+#[test]
+#[traced_test]
+/// runs through a standard Discover Offer Request Ack,
+/// then resends Request to renew the lease
+fn test_rapid_commit() -> Result<()> {
+    let _srv = DhcpServerEnv::start(
+        "basic.yaml",
+        "basic.db",
+        "dora_test",
+        "dhcpcli",
+        "dhcpsrv",
+        "192.168.2.1",
+    );
+    // use veth_cli created in start()
+    let settings = ClientSettingsBuilder::default()
+        .iface_name("dhcpcli")
+        .target("192.168.2.1".parse::<std::net::IpAddr>().unwrap())
+        .port(9900_u16)
+        .build()?;
+    // create a client that sends dhcpv4 messages
+    let mut client = Client::<v4::Message>::new(settings);
+    // create DISCOVER msg & send
+    let msg_args = DiscoverBuilder::default()
+        .giaddr([192, 168, 2, 1])
+        .opts(vec![v4::DhcpOption::RapidCommit])
+        .build()?;
+    let resp = client.run(MsgType::Discover(msg_args))?;
+
+    assert_eq!(resp.opts().msg_type().unwrap(), v4::MessageType::Ack);
+
+    // pedantic drop
+    drop(_srv);
+    Ok(())
+}
+
 /// standard negotiation but with a chaddr present in the reserved space
 #[test]
 #[traced_test]

--- a/bin/tests/test_configs/basic.yaml
+++ b/bin/tests/test_configs/basic.yaml
@@ -1,5 +1,6 @@
 chaddr_only: false
 bootp_enable: true
+rapid_commit: true
 interfaces: 
     - dhcpsrv
 networks:

--- a/docs/pi_setup.md
+++ b/docs/pi_setup.md
@@ -2,7 +2,7 @@
 
 You will need a Pi3 or later with either an onboard WiFi module or an external WiFi dongle. We also assume that you are running Raspbian (tested with 32-bit).
 
-### 0. SSH into the Pi
+## 0. SSH into the Pi
 
 Ensure everything is up to date with:
 

--- a/example.yaml
+++ b/example.yaml
@@ -1,15 +1,20 @@
-# Normally, client id is determined by (opt 61) client identifier option, 
+# (default false) Normally, client id is determined by (opt 61) client identifier option, 
 # or the DHCP header field `chaddr`. Sometimes, we want to configure
 # the server to only look at the `chaddr` field. Setting `chaddr_only` to true
 # will do that.
 #
 # chaddr_only: false
 #
-# Enable BOOTP support. Dora supports only RFC1497. BOOTP clients
+# (default false) Enable BOOTP support. Dora supports only RFC1497. BOOTP clients
 # will be assigned an IP based on their chaddr, they don't have client-ids.
 # The `lease_time` property of a reservation will be ignored
 #
 # bootp_enable: false
+#
+# (default false) Enable rapid commit RFC4093. If enabled, and a message is received with the
+# rapid commit option, then dora will attempt a 1-step lease instead of 2.
+#
+# rapid_commit: false
 #
 # Dora binds to inaddr_any, if an interface is specified dora will filter 
 # all traffic not from this interface.

--- a/libs/config/src/v4.rs
+++ b/libs/config/src/v4.rs
@@ -32,6 +32,7 @@ pub struct Config {
     interfaces: Vec<NetworkInterface>,
     chaddr_only: bool,
     bootp_enable: bool,
+    rapid_commit: bool,
     /// used to make a selection on which network or subnet to use
     networks: HashMap<Ipv4Net, Network>,
     v6: Option<crate::v6::Config>,
@@ -109,6 +110,7 @@ impl TryFrom<wire::Config> for Config {
             networks,
             chaddr_only: cfg.chaddr_only,
             bootp_enable: cfg.bootp_enable,
+            rapid_commit: cfg.rapid_commit,
             v6: cfg
                 .v6
                 .map(crate::v6::Config::try_from)
@@ -175,6 +177,11 @@ impl Config {
     /// Whether the server is configured to use bootp
     pub fn bootp_enabled(&self) -> bool {
         self.bootp_enable
+    }
+
+    /// Whether the server is configured to use bootp
+    pub fn rapid_commit(&self) -> bool {
+        self.rapid_commit
     }
 
     /// If opt 61 (client id) exists return that, otherwise return `chaddr` from the message

--- a/libs/config/src/wire/mod.rs
+++ b/libs/config/src/wire/mod.rs
@@ -17,6 +17,8 @@ pub struct Config {
     pub chaddr_only: bool,
     #[serde(default = "default_bootp_enable")]
     pub bootp_enable: bool,
+    #[serde(default = "default_rapid_commit")]
+    pub rapid_commit: bool,
     #[serde(default)]
     pub networks: HashMap<Ipv4Net, v4::Net>,
     pub v6: Option<v6::Config>,
@@ -47,6 +49,10 @@ pub const fn default_chaddr_only() -> bool {
 }
 
 pub const fn default_bootp_enable() -> bool {
+    false
+}
+
+pub const fn default_rapid_commit() -> bool {
     false
 }
 

--- a/libs/config/src/wire/v6.rs
+++ b/libs/config/src/wire/v6.rs
@@ -135,7 +135,8 @@ fn encode_opt<'a, T, F>(data: &[T], f: F, e: &mut Encoder<'a>) -> EncodeResult<(
 where
     F: Fn(&T, &mut Encoder<'a>) -> EncodeResult<()>,
 {
-    e.write_u16((data.len() * std::mem::size_of::<T>()) as u16)?;
+    // size_of_val removes data.len() * mem::size_of::<T>()
+    e.write_u16((std::mem::size_of_val(data)) as u16)?;
     for thing in data {
         f(thing, e)?;
     }

--- a/libs/ip-manager/src/lib.rs
+++ b/libs/ip-manager/src/lib.rs
@@ -215,7 +215,7 @@ where
                     Err(_) => None,
                 }
             };
-            match self.ping_cache.get_with(ip, async { fut.await }).await {
+            match self.ping_cache.get_with(ip, fut).await {
                 Some(_reply) => Err(IpError::AddrInUse(ip)),
                 None => Ok(()),
             }

--- a/libs/ip-manager/src/sqlite.rs
+++ b/libs/ip-manager/src/sqlite.rs
@@ -30,16 +30,6 @@ impl Clone for SqliteDb {
 
 impl SqliteDb {
     pub async fn new(uri: impl AsRef<str>) -> Result<Self, sqlx::Error> {
-        // in memory sqlite will clear the db after all conns close,
-        // to keep it alive for testing-- we can make sure conns _never_ close.
-        //
-        // let inner = if uri.as_ref().contains("memory") {
-        //     sqlx::sqlite::SqlitePoolOptions::new()
-        //         .idle_timeout(None)
-        //         .max_lifetime(None)
-        //         .connect(uri.as_ref())
-        //         .await?
-        // } else {
         let mut opts = SqliteConnectOptions::from_str(uri.as_ref())?
             .synchronous(sqlx::sqlite::SqliteSynchronous::Normal)
             .create_if_missing(true);
@@ -47,7 +37,6 @@ impl SqliteDb {
         opts.log_statements(tracing::log::LevelFilter::Trace);
 
         let inner = SqlitePool::connect_with(opts).await?;
-        // };
         sqlx::migrate!("../../migrations").run(&inner).await?;
         Ok(Self { inner })
     }

--- a/plugins/leases/src/lib.rs
+++ b/plugins/leases/src/lib.rs
@@ -159,8 +159,12 @@ where
         // TODO: we should probably set the expiry time to NULL but for now, 40 years in the future
         let expires_at = SystemTime::now() + Duration::from_secs(60 * 60 * 24 * 7 * 12 * 40);
         let state = Some(IpState::Lease);
-        self.first_available(ctx, client_id, network, classes, expires_at, state)
-            .await
+        let resp = self
+            .first_available(ctx, client_id, network, classes, expires_at, state)
+            .await;
+        ctx.filter_dhcp_opts();
+
+        resp
     }
 
     /// uses requested ip from client, or the first available IP in the range

--- a/plugins/message-type/src/lib.rs
+++ b/plugins/message-type/src/lib.rs
@@ -98,7 +98,18 @@ impl Plugin<Message> for MsgType {
                 subnet
             }
         };
+        let rapid_commit = ctx
+            .decoded_msg()
+            .opts()
+            .get(OptionCode::RapidCommit)
+            .is_some()
+            && self.cfg.v4().rapid_commit();
+
         match msg_type {
+            Some(MessageType::Discover) if rapid_commit => {
+                resp.opts_mut()
+                    .insert(DhcpOption::MessageType(MessageType::Ack));
+            }
             Some(MessageType::Discover) => {
                 resp.opts_mut()
                     .insert(DhcpOption::MessageType(MessageType::Offer));


### PR DESCRIPTION
It was easiest to build dynamic bootp off of the rapid commit PR, so this includes RFC 4093. Adds support for bootp + vendor extensions from RFC 1497, but will dynamically assign leases instead of restricting to just static assignment.

BOOTP leases don't have an expiry and don't include some options that exist only in DHCP.

closes #18 