### PR TITLE
add class built ins

### DIFF
--- a/bin/tests/basic.rs
+++ b/bin/tests/basic.rs
@@ -605,6 +605,45 @@ fn test_vendor_class() -> Result<()> {
     Ok(())
 }
 
+/// send a Discover with vendor id "docsis3.0"
+/// we've got a class that has 1 range with this class guarding it,
+#[test]
+#[traced_test]
+fn test_vendor_class_builtin() -> Result<()> {
+    let _srv = DhcpServerEnv::start(
+        "vendor.yaml",
+        "vendor.db",
+        "dora_test",
+        "dhcpcli",
+        "dhcpsrv",
+        "192.168.2.1",
+    );
+    // use veth_cli created in start()
+    let settings = ClientSettingsBuilder::default()
+        .iface_name("dhcpcli")
+        .target("192.168.2.1".parse::<std::net::IpAddr>().unwrap())
+        .port(9900_u16)
+        .build()?;
+    // create a client that sends dhcpv4 messages
+    let mut client = Client::<v4::Message>::new(settings);
+    // create DISCOVER msg & send
+    let msg_args = DiscoverBuilder::default()
+        .giaddr([192, 168, 2, 1])
+        .req_list([v4::OptionCode::VendorExtensions])
+        .opts([v4::DhcpOption::ClassIdentifier(b"docsis3.0".to_vec())])
+        .build()?;
+    let resp = client.run(MsgType::Discover(msg_args))?;
+
+    assert_eq!(resp.opts().msg_type().unwrap(), v4::MessageType::Offer);
+    let v4::DhcpOption::VendorExtensions(vendor_ext) = resp.opts().get(v4::OptionCode::VendorExtensions).unwrap() else {
+        bail!("vendor extensions not present");
+    };
+    // classes.yaml adds [1,2,3,4] as a Vec<u32>, translated into
+    let ret = vec![0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4];
+    assert_eq!(vendor_ext, &ret);
+    Ok(())
+}
+
 /// send a Discover with vendor id "iphone-dhcp-13"
 /// we've got a class that has 1 range with this class guarding it,
 /// an assertion on substring(option[60], 0, 7) == 'android'

--- a/bin/tests/test_configs/vendor.yaml
+++ b/bin/tests/test_configs/vendor.yaml
@@ -1,0 +1,36 @@
+interfaces: 
+    - dhcpsrv
+networks:
+    192.168.2.0/24:
+        probation_period: 86400
+        ranges:
+            -
+                class: testclass
+                start: 192.168.2.100
+                end: 192.168.2.103
+                config:
+                    lease_time:
+                        default: 3600
+                options:
+                    values:
+                        subnet_mask:
+                            type: ip
+                            value: 192.168.1.1
+                        routers:
+                            type: ip
+                            value: [ 192.168.1.1 ]
+                        domain_name_servers:
+                            type: ip
+                            value: [ 1.1.1.1 ]
+
+client_classes:  
+    v4:
+        -
+            name: testclass
+            assert: "member('VENDOR_CLASS_docsis3.0')"
+            options:
+                values:
+                    vendor_extensions:
+                        type: u32
+                        value: [1, 2, 3, 4]
+

--- a/bin/tests/test_configs/vendor.yaml
+++ b/bin/tests/test_configs/vendor.yaml
@@ -33,4 +33,6 @@ client_classes:
                     vendor_extensions:
                         type: u32
                         value: [1, 2, 3, 4]
-
+        -
+            name: DROP
+            assert: "member('VENDOR_CLASS_foobar')"

--- a/libs/client-classification/benches/my_benchmark.rs
+++ b/libs/client-classification/benches/my_benchmark.rs
@@ -29,7 +29,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     chaddr,
                     opts,
                     msg: &v4::Message::default(),
-                    deps: HashSet::new(),
+                    member: HashSet::new(),
                 };
                 client_classification::eval(
                     &client_classification::ast::build_ast(tokens).unwrap(),
@@ -61,7 +61,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     chaddr,
                     opts,
                     msg: &v4::Message::default(),
-                    deps: HashSet::new(),
+                    member: HashSet::new(),
                 };
                 client_classification::eval(&ast, &args).unwrap()
             })

--- a/libs/client-classification/src/grammar.pest
+++ b/libs/client-classification/src/grammar.pest
@@ -20,6 +20,21 @@ option = { "option[" ~ integer ~ "]" }
 relay = { "relay4[" ~ integer ~ "]" }
 member = { "member(" ~ string ~ ")" }
 
+builtin = _{
+    builtin_bootp
+    | builtin_known
+    | builtin_unknown
+    | builtin_all
+    | builtin_drop
+    | builtin_vendor
+}
+    builtin_bootp = @{ "BOOTP" }
+    builtin_known = @{ "KNOWN" }
+    builtin_unknown = @{ "UNKNOWN" }
+    builtin_all = @{ "ALL" }
+    builtin_drop = @{ "DROP" }
+    builtin_vendor = @{ "VENDOR_CLASS_" ~ ANY }
+
 pkt = _{ 
     pkt_mac
     | pkt_hlen

--- a/libs/client-classification/src/grammar.pest
+++ b/libs/client-classification/src/grammar.pest
@@ -20,20 +20,19 @@ option = { "option[" ~ integer ~ "]" }
 relay = { "relay4[" ~ integer ~ "]" }
 member = { "member(" ~ string ~ ")" }
 
-builtin = _{
-    builtin_bootp
-    | builtin_known
-    | builtin_unknown
-    | builtin_all
-    | builtin_drop
-    | builtin_vendor
-}
-    builtin_bootp = @{ "BOOTP" }
-    builtin_known = @{ "KNOWN" }
-    builtin_unknown = @{ "UNKNOWN" }
-    builtin_all = @{ "ALL" }
-    builtin_drop = @{ "DROP" }
-    builtin_vendor = @{ "VENDOR_CLASS_" ~ ANY }
+// builtin = _{
+//     builtin_bootp
+//     | builtin_known
+//     | builtin_unknown
+//     | builtin_all
+//     | builtin_drop
+//     | builtin_vendor
+// }
+//     builtin_bootp = @{ "BOOTP" }
+//     builtin_known = @{ "KNOWN" }
+//     builtin_unknown = @{ "UNKNOWN" }
+//     builtin_all = @{ "ALL" }
+//     builtin_vendor = @{ "VENDOR_CLASS_" ~ ANY }
 
 pkt = _{ 
     pkt_mac

--- a/libs/client-classification/src/lib.rs
+++ b/libs/client-classification/src/lib.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 pub mod ast;
 pub use ast::{Expr, ParseErr, ParseResult};
 
-pub const DROP_CLASS_NAME: &str = "DROP";
+pub const DROP_CLASS: &str = "DROP";
 // the following classes can be used in `member()`
 pub const VENDOR_PREFIX_CLASS: &str = "VENDOR_CLASS_";
 pub const ALL_CLASS: &str = "ALL";

--- a/libs/client-classification/src/lib.rs
+++ b/libs/client-classification/src/lib.rs
@@ -746,4 +746,23 @@ mod tests {
             "docsis3.0"
         );
     }
+
+    #[test]
+    fn test_parse_fail() {
+        let args = Args {
+            chaddr: &hex::decode(hex::encode("foo")).unwrap(),
+            opts: HashMap::new(),
+            msg: &v4::Message::default(),
+            member: HashSet::new(),
+        };
+        let expr = ast::parse("hexsting(0x1234,':')"); // should fail
+        assert!(expr.is_err());
+        assert!(ast::parse("foobar").is_err()); // should fail)
+        assert!(ast::parse("option(60) ==").is_err());
+        // should fail to eval bool == string
+        match eval(&ast::parse("true == 'foo'").unwrap(), &args) {
+            Err(EvalErr::ExpectedBool(Val::String(s))) => assert_eq!(&s, &"foo"),
+            _ => panic!(),
+        }
+    }
 }

--- a/libs/config/src/v4.rs
+++ b/libs/config/src/v4.rs
@@ -731,7 +731,16 @@ mod tests {
         // get matching classes
         // TODO: what should we do if there is an error processing client classes?
         let matched = cfg.eval_client_classes(&msg).unwrap().ok();
-        assert_eq!(matched.as_deref().unwrap(), &["my_class".to_owned()]);
+        assert_eq!(
+            matched
+                .as_deref()
+                .unwrap()
+                .iter()
+                .collect::<std::collections::HashSet<_>>(),
+            ["my_class".to_owned(), "ALL".to_owned()]
+                .iter()
+                .collect::<std::collections::HashSet<_>>()
+        );
         let net = cfg
             .range([10, 0, 0, 1], [10, 0, 0, 100], matched.as_deref())
             .unwrap();
@@ -754,7 +763,7 @@ mod tests {
                 .unwrap()
                 .into_iter()
                 .collect::<std::collections::HashSet<_>>(),
-            ["my_class", "a_class", "d_class", "b_class", "c_class"]
+            ["my_class", "a_class", "d_class", "b_class", "c_class", "ALL"]
                 .into_iter()
                 .map(|s| s.to_owned())
                 .collect::<std::collections::HashSet<_>>()

--- a/libs/config/src/v4.rs
+++ b/libs/config/src/v4.rs
@@ -161,7 +161,7 @@ impl Config {
     pub fn eval_client_classes(&self, req: &dhcproto::v4::Message) -> Option<Result<Vec<String>>> {
         self.client_classes
             .as_ref()
-            .map(|classes| classes.eval(req))
+            .map(|classes| classes.eval(req, self.bootp_enabled()))
     }
     pub fn classes(&self) -> Option<&ClientClasses> {
         self.client_classes.as_ref()

--- a/libs/config/src/wire/client_classes.rs
+++ b/libs/config/src/wire/client_classes.rs
@@ -13,5 +13,6 @@ pub struct ClientClasses {
 pub struct ClientClass {
     pub(crate) name: String,
     pub(crate) assert: String,
+    #[serde(default)]
     pub(crate) options: Options,
 }

--- a/libs/config/src/wire/v4.rs
+++ b/libs/config/src/wire/v4.rs
@@ -101,7 +101,7 @@ pub struct NetworkConfig {
     pub lease_time: MinMax,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Default)]
 pub struct Options {
     pub values: Opts,
 }
@@ -142,7 +142,7 @@ pub enum Condition {
     Options(Options),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct Opts(pub DhcpOptions);
 
 /// this type is only used as an intermediate representation

--- a/libs/ip-manager/src/lib.rs
+++ b/libs/ip-manager/src/lib.rs
@@ -34,6 +34,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
+const PING_TTL: u64 = 60;
 pub type ClientId = Option<Vec<u8>>;
 
 #[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
@@ -244,7 +245,7 @@ where
             store,
             ping_cache: moka::future::CacheBuilder::new(1_000)
                 // time_to_idle?
-                .time_to_live(Duration::from_secs(120))
+                .time_to_live(Duration::from_secs(PING_TTL))
                 .initial_capacity(1_000)
                 .build(),
         })


### PR DESCRIPTION
Adds `BOOTP`, `ALL`, `VENDOR_CLASS_`, `DROP` built in classes.

Similarly to kea, if the class name is `DROP` and its predicate evaluates to true, the packet will not receive a response. The `ALL` class is applied to all incoming packets. `VENDOR_CLASS_*` is like a shorthand for `option[60] = "*"`, for example: 

```
option[60] == "docsis3.0"
```
and 

```
member('VENDOR_CLASS_docsis3.0')
```

Will both evaluate to true if the packet contains "docsis3.0" as it's class.

Any packet received that is both a bootrequest & has no message type will be classified as BOOTP