### PR TITLE
draft: switch to single-threaded tokio rt

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -40,9 +40,6 @@ OPTIONS:
         --thread-name <THREAD_NAME>
             Worker thread name [env: THREAD_NAME=] [default: dora-dhcp-worker]
 
-        --threads <THREADS>
-            How many threads are spawned, default is the # of logical CPU cores [env: THREADS=]
-
         --timeout <TIMEOUT>
             default timeout, dora will respond within this window or drop [env: TIMEOUT=] [default:
             3]

--- a/bin/tests/common/env.rs
+++ b/bin/tests/common/env.rs
@@ -83,7 +83,7 @@ fn start_dhcp_server(config: &str, netns: &str, db: &str) -> Child {
     let workspace_root = env::var("WORKSPACE_ROOT").unwrap_or_else(|_| "..".to_owned());
     let config_path = format!("{workspace_root}/bin/tests/test_configs/{config}");
     let dora_debug = format!(
-        "./{workspace_root}/target/debug/dora -d={db} --config-path={config_path} --threads=2 --dora-log=debug --v4-addr=0.0.0.0:9900",
+        "./{workspace_root}/target/debug/dora -d={db} --config-path={config_path} --dora-log=debug --v4-addr=0.0.0.0:9900",
     );
     let cmd = format!("ip netns exec {netns} {dora_debug}");
 

--- a/dora-core/src/config.rs
+++ b/dora-core/src/config.rs
@@ -76,9 +76,6 @@ pub mod cli {
         /// channel size for various mpsc chans
         #[clap(long, env, value_parser, default_value_t = DEFAULT_CHANNEL_SIZE)]
         pub channel_size: usize,
-        /// How many threads are spawned, default is the # of logical CPU cores
-        #[clap(long, env, value_parser)]
-        pub threads: Option<usize>,
         /// Worker thread name
         #[clap(long, env, value_parser, default_value = DEFAULT_THREAD_NAME)]
         pub thread_name: String,

--- a/dora-core/src/server/mod.rs
+++ b/dora-core/src/server/mod.rs
@@ -478,7 +478,7 @@ macro_rules! impl_server {
                         // TODO: when `JoinSet` is removed from unstable-- add handles
                         // here.
                         // Using JoinSet will likely mean that we no longer need `_shutdown_complete`
-                        tokio::spawn(task.run());
+                        tokio::task::spawn_local(task.run());
                     }
                 }
                 Ok(())

--- a/external-api/src/lib.rs
+++ b/external-api/src/lib.rs
@@ -114,7 +114,7 @@ impl ExternalApi {
         let state = self.state.clone();
         let addr = self.addr;
 
-        tokio::spawn(async move {
+        tokio::task::spawn(async move {
             if let Err(err) = tokio::try_join!(ExternalApi::run(state, addr), self.listen_status())
             {
                 error!(?err, "health task returning, this should not happen")


### PR DESCRIPTION
Our current sqlite backend makes the multi-threaded runtime impossible to fully utilize. Perhaps it makes more sense to switch the the single-threaded runtime for now?

The tokio current thread rt will use 1 thread and spawn tasks concurrently on it.