### PR TITLE
client class: add .text

### DIFF
--- a/example.yaml
+++ b/example.yaml
@@ -306,7 +306,9 @@ v6:
 #   infix: == != or and (`1 == 1 and 2 != 3 or true`)
 #
 #   options: option[12]
-#    option[xx].hex: gets the byte string data section of option[12] (`option[12].hex == 'hostname'`)
+#    option[xx].hex: gets the data as a byte string. 
+#       You can still compare with 'strings' as long as the byte representation matches (`option[12].hex == 'hostname'` or `option[244].hex == 0x1234`)
+#    option[xx].text: gets the data as a utf-8 encoded string (`option[12].text == 'hostname'`)
 #    option[xx].exists: returns true/false if the option exists (`option[12].exists`)
 #
 #   pkt header:
@@ -332,7 +334,8 @@ v6:
 #
 #  Vendor classes:
 #
-#   To match on the standard option 60 vendor class identifier, use `option[60].hex` in your assertion.
+#   To match on the standard option 60 vendor class identifier, use `option[60].hex` or `option[60].text` 
+#   in your assertion— depending if you want a byte string or utf-8 string representation.
 #   You can then specify options for the class providing option 43, for the encapsulated vendor options.
 #   example.
 #       name: my_vendor_class
@@ -357,7 +360,7 @@ client_classes:
           # class name
           name: my_class
           # assertion will be run for each class defined
-          assert: "option[61].hex == 'foobar'"
+          assert: "option[60].text == 'foobar'"
           # any options defined here will be provided to the message
           options:
                 values:

--- a/libs/client-classification/src/ast.rs
+++ b/libs/client-classification/src/ast.rs
@@ -40,6 +40,7 @@ pub enum Expr {
     Not(Box<Expr>),
     // postfix
     ToHex(Box<Expr>),
+    ToText(Box<Expr>),
     Exists(Box<Expr>),
     SubOpt(Box<Expr>, u8),
     // infix
@@ -97,7 +98,10 @@ pub fn build_ast(pair: Pairs<Rule>) -> ParseResult<Expr> {
         .op(Op::infix(Rule::and, Assoc::Left))
         .op(Op::infix(Rule::equal, Assoc::Right) | Op::infix(Rule::neq, Assoc::Right))
         .op(Op::prefix(Rule::not))
-        .op(Op::postfix(Rule::to_hex) | Op::postfix(Rule::exists) | Op::postfix(Rule::sub_opt));
+        .op(Op::postfix(Rule::to_hex)
+            | Op::postfix(Rule::exists)
+            | Op::postfix(Rule::sub_opt)
+            | Op::postfix(Rule::to_text));
 
     parse_expr(pair, &climber)
 }
@@ -207,6 +211,7 @@ fn parse_expr(pairs: Pairs<Rule>, pratt: &PrattParser<Rule>) -> ParseResult<Expr
         .map_postfix(|lhs, op| {
             Ok(match op.as_rule() {
                 Rule::to_hex => Expr::ToHex(Box::new(lhs?)),
+                Rule::to_text => Expr::ToText(Box::new(lhs?)),
                 Rule::exists => Expr::Exists(Box::new(lhs?)),
                 Rule::sub_opt => {
                     // parse inner op (".option[_]"), should return Expr::Option(_)

--- a/libs/client-classification/src/grammar.pest
+++ b/libs/client-classification/src/grammar.pest
@@ -65,10 +65,11 @@ expr = { prefix* ~ primary ~ postfix* ~ (operation ~ prefix* ~ primary ~ postfix
 prefix = _{ not }
     not = { "not" } 
 
-postfix  =  _{ to_hex | exists | sub_opt }
+postfix  =  _{ to_hex | to_text | exists | sub_opt }
     to_hex    =   { ".hex" } 
+    to_text   =   { ".text" } 
     exists    =   { ".exists" } 
-    sub_opt    =   { "." ~ option } 
+    sub_opt   =   { "." ~ option } 
 
 primary = _{ hex | ip | integer | string | boolean | option | relay | pkt | substring | concat | ifelse | hexstring | member | "(" ~ expr ~ ")" }
 predicate = _{ SOI ~ expr ~ EOI }


### PR DESCRIPTION
Adds `.text` to client class expression, `option[x].text` will convert option data to string.