### PR TITLE
client_class: fix all keyword in substring()

### DIFF
--- a/libs/client-classification/src/grammar.pest
+++ b/libs/client-classification/src/grammar.pest
@@ -1,6 +1,9 @@
 // integer = @{ ASCII_DIGIT+ }
 integer    =  @{ (ASCII_NONZERO_DIGIT ~ ASCII_DIGIT+ | ASCII_DIGIT) }
 
+signed_int = @{ minus? ~ integer }
+minus = { "-" }
+
 string = @{ "'" ~ ( "''" | (!"'" ~ ANY) )* ~ "'" }
 
 ip = @{ ASCII_DIGIT{1,3} ~ "." ~ ASCII_DIGIT{1,3} ~ "." ~ ASCII_DIGIT{1,3} ~ "." ~ ASCII_DIGIT{1,3} }
@@ -8,6 +11,8 @@ ip = @{ ASCII_DIGIT{1,3} ~ "." ~ ASCII_DIGIT{1,3} ~ "." ~ ASCII_DIGIT{1,3} ~ "."
 hex = @{ "0x" ~ ASCII_HEX_DIGIT* }
 
 boolean = @{ "true" | "false" }
+
+all = @{ "all" }
 
 operation = _{ equal | neq | and | or }
 	equal = { "==" }
@@ -55,7 +60,12 @@ pkt = _{
     pkt_msgtype = @{ "pkt4.msgtype" }
     pkt_transid = @{ "pkt4.transid" }
 
-substring = { "substring(" ~ expr ~ "," ~ integer ~ "," ~ integer ~ ")" }
+end = _{
+    signed_int | all
+}
+
+
+substring = { "substring(" ~ expr ~ "," ~ signed_int ~ "," ~ end ~ ")" }
 concat = { "concat(" ~ expr ~ "," ~ expr ~ ")" }
 hexstring = { "hexstring(" ~ expr ~ "," ~ string ~ ")" }
 ifelse = { "ifelse(" ~ expr ~ "," ~ expr ~ "," ~ expr ~ ")" }

--- a/libs/client-classification/src/lib.rs
+++ b/libs/client-classification/src/lib.rs
@@ -399,6 +399,31 @@ mod tests {
     }
 
     #[test]
+    fn test_substring_all() {
+        let args = Args {
+            chaddr: &hex::decode("010203040506").unwrap(),
+            opts: HashMap::new(),
+            msg: &v4::Message::default(),
+            member: HashSet::new(),
+        };
+        let expr = ast::parse("substring('foobar', 0, all) == 'foobar'").unwrap();
+        let val = eval(&expr, &args).unwrap();
+        assert_eq!(val, Val::Bool(true));
+
+        let expr = ast::parse("substring('foobar', -1, -3) == 'oba'").unwrap();
+        let val = eval(&expr, &args).unwrap();
+        assert_eq!(val, Val::Bool(true));
+
+        let expr = ast::parse("substring('foobar', 1, 3) == 'oob'").unwrap();
+        let val = eval(&expr, &args).unwrap();
+        assert_eq!(val, Val::Bool(true));
+
+        let expr = ast::parse("substring(0x123456, 1, 2) == 0x3456").unwrap();
+        let val = eval(&expr, &args).unwrap();
+        assert_eq!(val, Val::Bool(true));
+    }
+
+    #[test]
     fn test_substring_hex() {
         let mut opts = HashMap::new();
         opts.insert(


### PR DESCRIPTION
signed inputs for `substring()` weren't working, and the `all` as the last parameter wasn't parsed correctly