### PR TITLE
draft: add plugin unit tests

### DIFF
--- a/.github/actions-rs/grcov.yml
+++ b/.github/actions-rs/grcov.yml
@@ -5,6 +5,8 @@ filter: covered
 output-type: lcov
 ignore:
   - "*.cargo/*"
+  - "bin/*"
+  - "dora-cfg/*"
 excl-start: "grcov-excl-start"
 excl-stop: "grcov-excl-stop"
 excl-line: "grcov-excl-line|#\\[derive\\(|//!"

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -126,6 +126,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           override: true
+          components: llvm-tools-preview
       - name: Run coverage
         uses: actions-rs/cargo@v1
         with:
@@ -133,8 +134,8 @@ jobs:
           args: --all-features --exclude register_derive_impl --workspace --no-fail-fast
         env:
           CARGO_INCREMENTAL: "0"
-          RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests"
-          RUSTDOCFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests"
+          RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinstrument-coverage -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests"
+          RUSTDOCFLAGS: "-Zprofile -Ccodegen-units=1 -Cinstrument-coverage -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests"
           SQLX_OFFLINE: true
       - name: rust-grcov
         id: coverage

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,15 +1,22 @@
 {
-  "search.exclude": {
-    "**/.git": true,
-    "**/build": true,
-    "**/docker-context": true,
-    "**/target": true,
-    "**/resources": true
-  },
-  "files.watcherExclude": {
-    "**/.git/objects/**": true,
-    "**/.git/subtree-cache/**": true,
-    "**/target": true,
-    "**/build": true
-  }
+    "search.exclude": {
+        "**/.git": true,
+        "**/build": true,
+        "**/docker-context": true,
+        "**/target": true,
+        "**/resources": true
+    },
+    "files.watcherExclude": {
+        "**/.git/objects/**": true,
+        "**/.git/subtree-cache/**": true,
+        "**/target": true,
+        "**/build": true
+    },
+    "spellright.language": [
+        "en-US-10-1."
+    ],
+    "spellright.documentTypes": [
+        "markdown",
+        "latex"
+    ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1805,6 +1805,8 @@ dependencies = [
  "config",
  "dora-core",
  "register_derive",
+ "serde_yaml",
+ "tracing-test",
 ]
 
 [[package]]
@@ -3110,8 +3112,11 @@ version = "0.1.0"
 dependencies = [
  "config",
  "dora-core",
+ "hex",
  "message-type",
  "register_derive",
+ "serde_yaml",
+ "tracing-test",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ We _could_ go much faster by keeping leases in memory and appending to the db li
 ## Troubleshooting/Testing
 
 ### Using dhcpm
-[dhcpm](https://github.com/leshow/dhcpm) is a tool built in rust that that will mock dhcp requests and is highly useful for testing dhcp in an isolated manner. 
+
+[dhcpm](https://github.com/leshow/dhcpm) is a tool built in rust that that will mock dhcp requests and is highly useful for testing dhcp in an isolated manner.
 
 ### Using perfdhcp
 

--- a/dora-core/src/server/context.rs
+++ b/dora-core/src/server/context.rs
@@ -584,14 +584,14 @@ impl MsgContext<v4::Message> {
     /// and if there is no relay information, falls back on the IP of the interface
     /// the message was recv'd on
     pub fn subnet(&self) -> io::Result<Ipv4Addr> {
-        Ok(self
-            .relay_subnet()
-            .unwrap_or(self.interface().map(|int| int.ip()).ok_or_else(|| {
+        self.relay_subnet().or_else(|_| {
+            self.interface().map(|int| int.ip()).ok_or_else(|| {
                 io::Error::new(
                     io::ErrorKind::InvalidInput,
                     "no interface set for MsgContext",
                 )
-            })?))
+            })
+        })
     }
 
     /// looks in `decoded_msg` for `DhcpOption::ParameterRequestList` and provides any options

--- a/dora-core/src/server/mod.rs
+++ b/dora-core/src/server/mod.rs
@@ -358,6 +358,7 @@ impl RunInner<v6::Message> {
                             ?dst_addr,
                             ?iname,
                             %resp,
+                            "message created"
                         );
                         metrics::DHCPV6_BYTES_SENT.inc_by(msg.bytes().len() as u64);
                         self.ctx.set_dst_addr(dst_addr);

--- a/plugins/message-type/Cargo.toml
+++ b/plugins/message-type/Cargo.toml
@@ -11,3 +11,7 @@ dora-core = { path = "../../dora-core" }
 register_derive = { path = "../../libs/register_derive" }
 config = { path = "../../libs/config" }
 client-protection = { path = "../../libs/client-protection" }
+
+[dev-dependencies]
+serde_yaml = { workspace = true }
+tracing-test = "0.2.4"

--- a/plugins/static-addr/Cargo.toml
+++ b/plugins/static-addr/Cargo.toml
@@ -13,3 +13,7 @@ config = { path = "../../libs/config" }
 register_derive = { path = "../../libs/register_derive" }
 message-type = { path = "../message-type" }
 
+[dev-dependencies]
+serde_yaml = { workspace = true }
+tracing-test = "0.2.4"
+hex = "0.4"


### PR DESCRIPTION
~~I read using `llvm-tools-preview` and `-Cinstrument-coverage` you can get coverage data out of the integration tests, which would finally give an accurate %~~

doesn't seem to work. I added a few plugin unit tests instead