### PR TITLE
RFC 5107 - Server Identifier Override

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ It will pretty-print the internal dora config representation as well as parse th
 -   [v4 RFC4093](https://datatracker.ietf.org/doc/html/rfc4093)
 -   [v4 RFC6842](https://datatracker.ietf.org/doc/html/rfc6842)
 -   [v4 RFC3046](https://datatracker.ietf.org/doc/html/rfc3046)
+-   [v4 RFC5107](https://datatracker.ietf.org/doc/html/rfc5107)
 -   see [dhcproto](https://github.com/bluecatengineering/dhcproto) for protocol level support
 
 #### v6

--- a/plugins/message-type/src/lib.rs
+++ b/plugins/message-type/src/lib.rs
@@ -91,7 +91,7 @@ impl Plugin<Message> for MsgType {
             return Ok(Action::NoResponse);
         }
         // otherwise our interface IP as the id
-        let server_id = self
+        let cfg_server_id = self
             .cfg
             .v4()
             .server_id(meta.ifindex, subnet)
@@ -101,23 +101,23 @@ impl Plugin<Message> for MsgType {
         let sname = network.and_then(|net| net.server_name());
         let fname = network.and_then(|net| net.file_name());
         // message that will be returned
-        let mut resp = util::new_msg(req, server_id, sname, fname);
-        let server_id_override = util::get_server_identifier_override(req.opts());
+        let mut resp = util::new_msg(req, cfg_server_id, sname, fname);
+        let server_id_override = util::get_server_id_override(req.opts());
 
         // determine if we should use the server identifier override as the server identifier in the response message
         let use_server_id_override =
-            if let (Some(&override_id), Some(&DhcpOption::ServerIdentifier(server_identifier))) = (
+            if let (Some(override_id), Some(&DhcpOption::ServerIdentifier(msg_server_id))) = (
                 server_id_override,
                 req.opts().get(OptionCode::ServerIdentifier),
             ) {
-                override_id == server_identifier
+                override_id == msg_server_id
             } else {
                 false
             };
         // if there is a server identifier it must match either the server identifier override address or ours
-        if matches!(req.opts().get(OptionCode::ServerIdentifier), Some(DhcpOption::ServerIdentifier(id)) if *id != server_id && !id.is_unspecified() && !use_server_id_override)
+        if matches!(req.opts().get(OptionCode::ServerIdentifier), Some(DhcpOption::ServerIdentifier(id)) if *id != cfg_server_id && !id.is_unspecified() && !use_server_id_override)
         {
-            debug!(?server_id, "server identifier in msg doesn't match server address or server identifier override");
+            debug!(?cfg_server_id, "server identifier in msg doesn't match server address or server identifier override");
             return Ok(Action::NoResponse);
         }
         if req.opcode() == Opcode::BootReply {
@@ -130,12 +130,12 @@ impl Plugin<Message> for MsgType {
             // safe due to our previous check
             server_id_override.unwrap()
         } else {
-            &server_id
+            cfg_server_id
         };
 
         // add the correct server identifier to response
         resp.opts_mut()
-            .insert(DhcpOption::ServerIdentifier(*resp_server_id));
+            .insert(DhcpOption::ServerIdentifier(resp_server_id));
         // evaluate client classes
         let matched = util::client_classes(self.cfg.v4(), ctx)?;
         let addr = {
@@ -348,16 +348,17 @@ pub mod util {
         Ok(ctx)
     }
 
-    /// convenience for fetching ServerIdentifierOverride
-    pub fn get_server_identifier_override(dhcp_options: &v4::DhcpOptions) -> Option<&Ipv4Addr> {
+    /// Convenience for RFC 5107 compliance. Fetches the ServerIdentifierOverride suboption (11) from
+    /// RelayAgentInformation (82) to use in comparisons between the server id and override id.
+    pub fn get_server_id_override(opts: &v4::DhcpOptions) -> Option<Ipv4Addr> {
         // fetch the RelayAgentInformation option (option 82)
         if let Some(DhcpOption::RelayAgentInformation(relay_info)) =
-            dhcp_options.get(OptionCode::RelayAgentInformation)
+            opts.get(OptionCode::RelayAgentInformation)
         {
             // fetch the ServerIdentifierOverride suboption (suboption 11) from the relay information
             let override_info = relay_info.get(v4::relay::RelayCode::ServerIdentifierOverride);
             if let Some(v4::relay::RelayInfo::ServerIdentifierOverride(addr)) = override_info {
-                return Some(addr);
+                return Some(*addr);
             }
         }
         None
@@ -448,7 +449,7 @@ pub struct MatchedClasses(pub Vec<String>);
 
 #[cfg(test)]
 mod tests {
-    use util::get_server_identifier_override;
+    use util::get_server_id_override;
 
     use dora_core::dhcproto::v4::{self, relay};
     use tracing_test::traced_test;
@@ -518,10 +519,10 @@ mod tests {
         Ok(())
     }
 
-    // ensure the server identifier override is appropriately written to the response server identifier
+    // ensure the server identifier override is written to the response server identifier when they match
     #[tokio::test]
     #[traced_test]
-    async fn test_server_identifier_matches_override() -> Result<()> {
+    async fn test_server_id_eq_override() -> Result<()> {
         let cfg = DhcpConfig::parse_str(SAMPLE_YAML).unwrap();
         let plugin = MsgType::new(Arc::new(cfg.clone()))?;
         let mut ctx = util::blank_ctx(
@@ -533,7 +534,7 @@ mod tests {
 
         let mut relay_info = relay::RelayAgentInformation::default();
         relay_info.insert(relay::RelayInfo::ServerIdentifierOverride(
-            "10.0.0.1".parse().unwrap(),
+            "10.0.0.1".parse()?,
         ));
         // assign suboption 11 of DHCP relay info (opt 82)
         ctx.msg_mut()
@@ -542,23 +543,23 @@ mod tests {
         // assign the same address to the server identifier
         ctx.msg_mut()
             .opts_mut()
-            .insert(DhcpOption::ServerIdentifier("10.0.0.1".parse().unwrap()));
+            .insert(DhcpOption::ServerIdentifier("10.0.0.1".parse()?));
         plugin.handle(&mut ctx).await?;
 
-        let resp_server_identifier = ctx
+        let resp_server_id = ctx
             .resp_msg()
             .unwrap()
             .opts()
             .get(OptionCode::ServerIdentifier);
-        let msg_server_identifier_override = get_server_identifier_override(ctx.msg().opts());
+        let msg_server_id_override = get_server_id_override(ctx.msg().opts());
 
-        // get and compare the Ipv4Addrs from resp_server_identifier and resp_server_identifier_override
-        if let (Some(&DhcpOption::ServerIdentifier(addr1)), Some(&addr2)) =
-            (resp_server_identifier, msg_server_identifier_override)
+        // get and compare the Ipv4Addrs from resp_server_id and resp_server_id_override
+        if let (Some(&DhcpOption::ServerIdentifier(addr1)), Some(addr2)) =
+            (resp_server_id, msg_server_id_override)
         {
-            assert_eq!(&addr1, &addr2);
+            assert_eq!(addr1, addr2);
         } else {
-            panic!("Server identifier and server identifier override are not both Ipv4Addrs:\n\nOpt 54 = {:?}\nOpt 82 Subopt 11 = {:?}\n\n", resp_server_identifier, msg_server_identifier_override);
+            panic!("Server identifier and server identifier override are not both Ipv4Addrs:\n\nOpt 54 = {:?}\nOpt 82 Subopt 11 = {:?}\n\n", resp_server_id, msg_server_id_override);
         }
         // ensure we respond with an offer
         assert!(ctx
@@ -566,6 +567,38 @@ mod tests {
             .unwrap()
             .opts()
             .has_msg_type(v4::MessageType::Offer));
+        Ok(())
+    }
+
+    // ensure the server identifier override is not written to the response server identifier when they don't match
+    #[tokio::test]
+    #[traced_test]
+    async fn test_server_id_ne_override() -> Result<()> {
+        let cfg = DhcpConfig::parse_str(SAMPLE_YAML).unwrap();
+        let plugin = MsgType::new(Arc::new(cfg.clone()))?;
+        let mut ctx = util::blank_ctx(
+            "192.168.0.1:67".parse()?,
+            "192.168.0.1".parse()?,
+            "192.168.0.1".parse()?,
+            v4::MessageType::Discover,
+        )?;
+
+        let mut relay_info = relay::RelayAgentInformation::default();
+        relay_info.insert(relay::RelayInfo::ServerIdentifierOverride(
+            "10.0.0.2".parse()?,
+        ));
+        // assign suboption 11 of DHCP relay info (opt 82)
+        ctx.msg_mut()
+            .opts_mut()
+            .insert(v4::DhcpOption::RelayAgentInformation(relay_info));
+        // assign an address to the server identifier that does not match the override or our address
+        ctx.msg_mut()
+            .opts_mut()
+            .insert(DhcpOption::ServerIdentifier("10.0.0.10".parse()?));
+        let res = plugin.handle(&mut ctx).await?;
+        // when the the server id in the message matches neither the server id override nor our server
+        // id, we must not respond
+        assert_eq!(res, Action::NoResponse);
         Ok(())
     }
 }


### PR DESCRIPTION
After looking into Kea's implementation, it appears that they only do a [check](https://gitlab.isc.org/isc-projects/kea/-/blob/master/src/bin/dhcp4/dhcp4_srv.cc#L4145) to determine if the server identifier override matches the server identifier because they [do not store relay agent information](https://kea.readthedocs.io/en/kea-2.2.0/arm/dhcp4-srv.html#supported-dhcp-standards).

This PR currently adds a check to ensure the v4 message is processed when the server identifier (option 54) matches the relay agent server identifier override (option 82, suboption 11). I have also added a test to ensure that the server identifier override is correctly inserted into the response message and that we are responding when appropriate.

I would still like to check the implementation in dnsmasq and/or ISC DHCP server (but maybe ISC used the same implementation as with Kea?) and am open to any guidance or suggestions.

Closes #9