### PR TITLE
Implement server_id generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,6 +522,7 @@ dependencies = [
  "hex",
  "ipnet",
  "phf",
+ "rand",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/example.yaml
+++ b/example.yaml
@@ -194,12 +194,17 @@ networks:
 # responding to INFOREQ.
 v6:
     # optional, interfaces to bind
-    interfaces:
-        - enp6s0
-    # TODO: SERVER ID
-    # server_id:
-    #       type: DUID-LLT (default) | DUID-LL | DUID-EN | ...
-    #       value: ""
+    # interfaces:
+        # - enp6s0
+    # Optional, if server_id is not specified, we will generate an server identifer or use previous generated server identifier(if exists). Addtionally, if all settings are the same as previous settings, we will also use previous generated server identifier.
+    server_id:
+        duid_type: LLT # LLT (default) | LL | EN | UUID
+        identifier: fe80::c981:b769:461a:bfb4 # Optional, set blank or remove to auto-generate link-layer address. For LLT and LL, it must be a valid link-layer address.
+        time: 1111112 # Optional, set blank or remove to auto-generate time. For LLT, it must be a valid u32 timestamp
+        hardware_type: 1 # Optional, set blank or remove to auto-generate hardware type. For LL, it must be a valid u16 hardware type
+        #enterprise_id: 1 # Optional, set blank or remove to auto-generate enterprise id. For EN, it must be a valid u32 enterprise id
+        persist: true # Optional, default value is true. set false to generate a new DUID every time the server is restarted. Persist feature is now unimplemented.
+        server_id_path: ./server_id.json # optional. default is /var/lib/dora/server_id
     # global options (optional)
     options:
         values:
@@ -224,7 +229,8 @@ v6:
         2001:db8:1::/64: # https://en.wikipedia.org/wiki/IPv6_address#Documentation
             # optional - what interfaces we will apply to this network
             interfaces:
-                - enp6s0
+                # - enp6s0
+                - ens37
             # no explicit ranges (yet)
             config:
                 lease_time:

--- a/libs/config/Cargo.toml
+++ b/libs/config/Cargo.toml
@@ -17,6 +17,7 @@ trust-dns-proto = { workspace = true }
 base64 = "0.21.0"
 hex = "0.4"
 phf = { version = "0.11", features = ["macros"] }
+rand = "0.8"
 
 dora-core = { path = "../../dora-core" }
 client-classification = { path = "../client-classification" }

--- a/libs/config/sample/config_v6.yaml
+++ b/libs/config/sample/config_v6.yaml
@@ -1,0 +1,53 @@
+v6:
+    # optional, interfaces to bind
+    # interfaces:
+        # - enp6s0
+    # Optional, if server_id is not specified, we will generate an server identifer or use previous generated server identifier(if exists). Addtionally, if all settings are the same as previous settings, we will also use previous generated server identifier.
+    server_id:
+        duid_type: LLT # LLT (default) | LL | EN | UUID
+        identifier: fe80::c981:b769:461a:bfb4 # Optional, set blank or remove to auto-generate link-layer address. For LLT and LL, it must be a valid link-layer address.
+        time: 1111112 # Optional, set blank or remove to auto-generate time. For LLT, it must be a valid u32 timestamp
+        hardware_type: 1 # Optional, set blank or remove to auto-generate hardware type. For LL, it must be a valid u16 hardware type
+        persist: true # Optional, default value is true. set false to generate a new DUID every time the server is restarted. Persist feature is now unimplemented.
+        server_id_path: /var/lib/dora/server_id # optional. default is /var/lib/dora/server_id
+    # global options (optional)
+    options:
+        values:
+            # dns
+            23:
+                type: ip_list
+                value:
+                    - 2001:db8::1
+                    - 2001:db8::2
+    # optional
+    networks:
+        # subnet selection:
+        # we will attempt to match first the IP of the `interfaces` field below to determine
+        # which subnet to apply, if none is specified we will use the link-local, then the global IP
+        # of the interface we received the message on.
+        # (this method should be double checked, I'm not sure it's correct)
+        #
+        # https://kea.readthedocs.io/en/kea-1.6.0/arm/dhcp6-srv.html#dhcp6-config-subnets
+        # https://datatracker.ietf.org/doc/html/rfc8415#section-13.1
+        # https://techhub.hpe.com/eginfolib/networking/docs/switches/5130ei/5200-3942_l3-ip-svcs_cg/content/483572577.htm
+        #
+        2001:db8:1::/64: # https://en.wikipedia.org/wiki/IPv6_address#Documentation
+            # optional - what interfaces we will apply to this network
+            #interfaces:
+                # - enp6s0
+            # no explicit ranges (yet)
+            config:
+                lease_time:
+                    default: 3600
+                preferred_time:
+                    default: 3600
+            # same with options
+            # inspiration: https://kea.readthedocs.io/en/kea-2.2.0/arm/dhcp6-srv.html?highlight=router%20advertisement#dhcp6-std-options-list
+            options:
+                values:
+                    # dns
+                    23:
+                        type: ip_list
+                        value:
+                            - 2001:db8::1
+                            - 2001:db8::2

--- a/libs/config/sample/config_v6_EN.yaml
+++ b/libs/config/sample/config_v6_EN.yaml
@@ -1,0 +1,52 @@
+v6:
+    # optional, interfaces to bind
+    # interfaces:
+        # - enp6s0
+    # Optional, if server_id is not specified, we will generate an server identifer or use previous generated server identifier(if exists). Addtionally, if all settings are the same as previous settings, we will also use previous generated server identifier.
+    server_id:
+        duid_type: EN # LLT (default) | LL | EN | UUID
+        identifier: 1122FFFE3842 # Optional, set blank or remove to auto-generate link-layer address. For LLT and LL, it must be a valid link-layer address.
+        enterprise_id: 23
+        persist: true # Optional, default value is true. set false to generate a new DUID every time the server is restarted. Persist feature is now unimplemented.
+        server_id_path: /var/lib/dora/server_id # optional. default is /var/lib/dora/server_id
+    # global options (optional)
+    options:
+        values:
+            # dns
+            23:
+                type: ip_list
+                value:
+                    - 2001:db8::1
+                    - 2001:db8::2
+    # optional
+    networks:
+        # subnet selection:
+        # we will attempt to match first the IP of the `interfaces` field below to determine
+        # which subnet to apply, if none is specified we will use the link-local, then the global IP
+        # of the interface we received the message on.
+        # (this method should be double checked, I'm not sure it's correct)
+        #
+        # https://kea.readthedocs.io/en/kea-1.6.0/arm/dhcp6-srv.html#dhcp6-config-subnets
+        # https://datatracker.ietf.org/doc/html/rfc8415#section-13.1
+        # https://techhub.hpe.com/eginfolib/networking/docs/switches/5130ei/5200-3942_l3-ip-svcs_cg/content/483572577.htm
+        #
+        2001:db8:1::/64: # https://en.wikipedia.org/wiki/IPv6_address#Documentation
+            # optional - what interfaces we will apply to this network
+            #interfaces:
+                # - enp6s0
+            # no explicit ranges (yet)
+            config:
+                lease_time:
+                    default: 3600
+                preferred_time:
+                    default: 3600
+            # same with options
+            # inspiration: https://kea.readthedocs.io/en/kea-2.2.0/arm/dhcp6-srv.html?highlight=router%20advertisement#dhcp6-std-options-list
+            options:
+                values:
+                    # dns
+                    23:
+                        type: ip_list
+                        value:
+                            - 2001:db8::1
+                            - 2001:db8::2

--- a/libs/config/sample/config_v6_LL.yaml
+++ b/libs/config/sample/config_v6_LL.yaml
@@ -1,0 +1,52 @@
+v6:
+    # optional, interfaces to bind
+    # interfaces:
+        # - enp6s0
+    # Optional, if server_id is not specified, we will generate an server identifer or use previous generated server identifier(if exists). Addtionally, if all settings are the same as previous settings, we will also use previous generated server identifier.
+    server_id:
+        duid_type: LL # LLT (default) | LL | EN | UUID
+        identifier: fe80::c981:b769:461a:bfb4 # Optional, set blank or remove to auto-generate link-layer address. For LLT and LL, it must be a valid link-layer address.
+        hardware_type: 2 # Optional, set blank or remove to auto-generate hardware type. For LL, it must be a valid u16 hardware type
+        persist: true # Optional, default value is true. set false to generate a new DUID every time the server is restarted. Persist feature is now unimplemented.
+        server_id_path: /var/lib/dora/server_id # optional. default is /var/lib/dora/server_id
+    # global options (optional)
+    options:
+        values:
+            # dns
+            23:
+                type: ip_list
+                value:
+                    - 2001:db8::1
+                    - 2001:db8::2
+    # optional
+    networks:
+        # subnet selection:
+        # we will attempt to match first the IP of the `interfaces` field below to determine
+        # which subnet to apply, if none is specified we will use the link-local, then the global IP
+        # of the interface we received the message on.
+        # (this method should be double checked, I'm not sure it's correct)
+        #
+        # https://kea.readthedocs.io/en/kea-1.6.0/arm/dhcp6-srv.html#dhcp6-config-subnets
+        # https://datatracker.ietf.org/doc/html/rfc8415#section-13.1
+        # https://techhub.hpe.com/eginfolib/networking/docs/switches/5130ei/5200-3942_l3-ip-svcs_cg/content/483572577.htm
+        #
+        2001:db8:1::/64: # https://en.wikipedia.org/wiki/IPv6_address#Documentation
+            # optional - what interfaces we will apply to this network
+            #interfaces:
+                # - enp6s0
+            # no explicit ranges (yet)
+            config:
+                lease_time:
+                    default: 3600
+                preferred_time:
+                    default: 3600
+            # same with options
+            # inspiration: https://kea.readthedocs.io/en/kea-2.2.0/arm/dhcp6-srv.html?highlight=router%20advertisement#dhcp6-std-options-list
+            options:
+                values:
+                    # dns
+                    23:
+                        type: ip_list
+                        value:
+                            - 2001:db8::1
+                            - 2001:db8::2

--- a/libs/config/sample/config_v6_UUID.yaml
+++ b/libs/config/sample/config_v6_UUID.yaml
@@ -1,0 +1,51 @@
+v6:
+    # optional, interfaces to bind
+    # interfaces:
+        # - enp6s0
+    # Optional, if server_id is not specified, we will generate an server identifer or use previous generated server identifier(if exists). Addtionally, if all settings are the same as previous settings, we will also use previous generated server identifier.
+    server_id:
+        duid_type: UUID # LLT (default) | LL | EN | UUID
+        identifier: 451c810bf191a92abf3768dd1ed61f3a  # Optional, set blank or remove to auto-generate link-layer address. For LLT and LL, it must be a valid link-layer address.
+        persist: true # Optional, default value is true. set false to generate a new DUID every time the server is restarted. Persist feature is now unimplemented.
+        server_id_path: /var/lib/dora/server_id # optional. default is /var/lib/dora/server_id
+    # global options (optional)
+    options:
+        values:
+            # dns
+            23:
+                type: ip_list
+                value:
+                    - 2001:db8::1
+                    - 2001:db8::2
+    # optional
+    networks:
+        # subnet selection:
+        # we will attempt to match first the IP of the `interfaces` field below to determine
+        # which subnet to apply, if none is specified we will use the link-local, then the global IP
+        # of the interface we received the message on.
+        # (this method should be double checked, I'm not sure it's correct)
+        #
+        # https://kea.readthedocs.io/en/kea-1.6.0/arm/dhcp6-srv.html#dhcp6-config-subnets
+        # https://datatracker.ietf.org/doc/html/rfc8415#section-13.1
+        # https://techhub.hpe.com/eginfolib/networking/docs/switches/5130ei/5200-3942_l3-ip-svcs_cg/content/483572577.htm
+        #
+        2001:db8:1::/64: # https://en.wikipedia.org/wiki/IPv6_address#Documentation
+            # optional - what interfaces we will apply to this network
+            #interfaces:
+                # - enp6s0
+            # no explicit ranges (yet)
+            config:
+                lease_time:
+                    default: 3600
+                preferred_time:
+                    default: 3600
+            # same with options
+            # inspiration: https://kea.readthedocs.io/en/kea-2.2.0/arm/dhcp6-srv.html?highlight=router%20advertisement#dhcp6-std-options-list
+            options:
+                values:
+                    # dns
+                    23:
+                        type: ip_list
+                        value:
+                            - 2001:db8::1
+                            - 2001:db8::2

--- a/libs/config/sample/config_v6_no_persist.yaml
+++ b/libs/config/sample/config_v6_no_persist.yaml
@@ -1,0 +1,49 @@
+v6:
+    # optional, interfaces to bind
+    # interfaces:
+        # - enp6s0
+    # Optional, if server_id is not specified, we will generate an server identifer or use previous generated server identifier(if exists). Addtionally, if all settings are the same as previous settings, we will also use previous generated server identifier.
+    server_id:
+        duid_type: LLT # LLT (default) | LL | EN | UUID
+        persist: false # Optional, default value is true. set false to generate a new DUID every time the server is restarted. Persist feature is now unimplemented.
+    # global options (optional)
+    options:
+        values:
+            # dns
+            23:
+                type: ip_list
+                value:
+                    - 2001:db8::1
+                    - 2001:db8::2
+    # optional
+    networks:
+        # subnet selection:
+        # we will attempt to match first the IP of the `interfaces` field below to determine
+        # which subnet to apply, if none is specified we will use the link-local, then the global IP
+        # of the interface we received the message on.
+        # (this method should be double checked, I'm not sure it's correct)
+        #
+        # https://kea.readthedocs.io/en/kea-1.6.0/arm/dhcp6-srv.html#dhcp6-config-subnets
+        # https://datatracker.ietf.org/doc/html/rfc8415#section-13.1
+        # https://techhub.hpe.com/eginfolib/networking/docs/switches/5130ei/5200-3942_l3-ip-svcs_cg/content/483572577.htm
+        #
+        2001:db8:1::/64: # https://en.wikipedia.org/wiki/IPv6_address#Documentation
+            # optional - what interfaces we will apply to this network
+            #interfaces:
+                # - enp6s0 
+            # no explicit ranges (yet)
+            config:
+                lease_time:
+                    default: 3600
+                preferred_time:
+                    default: 3600
+            # same with options
+            # inspiration: https://kea.readthedocs.io/en/kea-2.2.0/arm/dhcp6-srv.html?highlight=router%20advertisement#dhcp6-std-options-list
+            options:
+                values:
+                    # dns
+                    23:
+                        type: ip_list
+                        value:
+                            - 2001:db8::1
+                            - 2001:db8::2

--- a/libs/config/src/lib.rs
+++ b/libs/config/src/lib.rs
@@ -11,8 +11,11 @@ use dora_core::pnet::{
     datalink::NetworkInterface,
     ipnetwork::{IpNetwork, Ipv4Network},
 };
+use serde::{Serialize, Deserialize};
 use tracing::debug;
-
+use rand::{self, RngCore};
+use wire::v6::ServerDuid;
+use dora_core::dhcproto::v6::duid::Duid;
 /// server config
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DhcpConfig {
@@ -53,7 +56,7 @@ impl EnvConfig {
 
 impl DhcpConfig {
     /// attempts to decode the config first as JSON, then YAML, finally erroring if neither work
-    pub fn parse<P: AsRef<Path>>(path: P) -> Result<Self> {
+        pub fn parse<P: AsRef<Path>>(path: P) -> Result<Self> {
         let path = path.as_ref();
         let config = v4::Config::new(
             std::fs::read_to_string(path)
@@ -63,7 +66,7 @@ impl DhcpConfig {
 
         Ok(Self { v4: config })
     }
-    /// attempts to decode the config first as JSON, then YAML, finally erroring if neither work
+        /// attempts to decode the config first as JSON, then YAML, finally erroring if neither work
     pub fn parse_str<S: AsRef<str>>(s: S) -> Result<Self> {
         let config = v4::Config::new(s.as_ref())?;
         debug!(?config);
@@ -179,3 +182,63 @@ pub fn renew(t: Duration) -> Duration {
 pub fn rebind(t: Duration) -> Duration {
     t * 7 / 8
 }
+
+pub fn generate_random_bytes(len: usize) -> Vec<u8> {
+    let mut ident = Vec::with_capacity(len);
+    rand::thread_rng().fill_bytes(&mut ident);
+    ident
+}
+
+pub fn generate_bytes_from_string(s: &String) -> Result<Vec<u8>> {
+    let mut ident = Vec::new();
+    let mut i = 0;
+    while i < s.len() {
+        let byte = u8::from_str_radix(&s[i..i + 2], 16)
+            .context("should be a valid hex string")?;
+        ident.push(byte);
+        i += 2;
+    }
+    Ok(ident)
+}
+
+pub fn generate_string_from_bytes(bytes: &Vec<u8>) -> Result<String> {
+    //Generate hex string from bytes, for example 0x00 0x01 0x02 0x03 -> "00010203"
+    let mut ident = String::new();
+    for byte in bytes {
+        ident.push_str(&format!("{:02x}", byte));
+    }
+    Ok(ident)
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
+pub struct IdentifierFileStruct {
+    pub identifier: String,
+    pub duid_config: Option<ServerDuid>,
+}
+
+impl IdentifierFileStruct {
+    pub fn new(identifier: &String, duid_config: &ServerDuid) -> Self {
+        Self {
+            identifier: identifier.clone(),
+            duid_config: Some(duid_config.clone())
+        }
+    }
+    
+    pub fn to_json(&self,path: &Path) -> Result<()> {
+        let file = std::fs::File::create(path)?;
+        serde_json::to_writer_pretty(file, self)?;
+        Ok(())
+    }
+
+    pub fn from_json(path: &Path) -> Result<Self> {
+        let file = std::fs::File::open(path)?;
+        let identifier_file_struct: IdentifierFileStruct = serde_json::from_reader(file)?;
+        Ok(identifier_file_struct)
+    }
+
+    pub fn duid(&self) -> Result<Duid> {
+        let duid_bytes = generate_bytes_from_string(&self.identifier).context("server identifier should be a valid hex string")?;
+        Ok(Duid::from(duid_bytes))
+    }
+}
+

--- a/libs/config/src/wire/v6.rs
+++ b/libs/config/src/wire/v6.rs
@@ -15,6 +15,7 @@ use crate::wire::{MaybeList, MinMax};
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, Default)]
 pub struct Config {
     pub interfaces: Option<Vec<String>>,
+    pub server_id: Option<ServerDuid>,
     pub networks: HashMap<Ipv6Net, Net>,
     // TODO: better defaults than blank? pull information from the system
     #[serde(default)]
@@ -27,7 +28,6 @@ pub struct Net {
     #[serde(default)]
     pub options: Options,
     pub interfaces: Option<Vec<String>>,
-    // pub duid: ServerDuid,
     /// ping check is an optional value, when turned on an ICMP echo request will be sent
     /// before OFFER for this network
     #[serde(default)]
@@ -43,14 +43,31 @@ pub struct Net {
     pub authoritative: bool,
 }
 
-// TODO allow configuring server id
-// #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
-// #[serde(tag = "type", content = "value", rename_all = "snake_case")]
-// pub enum ServerDuid {
-//     LLT(String),
-//     LL(String),
-//     EN(String),
-// }
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub enum DuidType {
+    LLT,
+    LL,
+    EN,
+    UUID,
+}
+
+impl Default for DuidType {
+    fn default() -> Self {
+        Self::LLT
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
+pub struct ServerDuid {
+    pub duid_type: DuidType,
+    pub htype: Option<u16>, //according to https://datatracker.ietf.org/doc/html/rfc8415#section-11.1 htype is a 16-digit unsigned value, unlike 8 digit number in DHCP v4. Will it be a problem?
+    pub identifier: Option<String>,
+    pub time: Option<u32>,
+    pub enterprise_id: Option<u32>,
+    pub persist: Option<bool>,
+    pub server_id_path: Option<String>,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct NetworkConfig {


### PR DESCRIPTION
Hi, I have been working on a plan to enhance DHCPv6 support of this project for a long time. The generation of Server Identifier is the first step of this plan, and also the very first step of a DHCPv6 serving process.

I got some inspiration from kea, a high-performance DHCP server engine, and I implemented the support of 4 types of server identifier: LLT, LL, EN and DUID. Some major points of my codes are:
(1) The definition of certain configuration of server identifier. These can be found in various config yaml files I added. 
(2) The fix of finding the local link layer address if we never define the interfaces in config. 
(3) The implementation of reusing the DUID generated at the first time DHCPv6 is used. The DUID will only be reused if the configuration has not changed since the last time.
(4) Some tests.
