### PR TITLE
change default cache_threshold to disable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2281,9 +2281,9 @@ dependencies = [
 
 [[package]]
 name = "parse-zoneinfo"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41"
+checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
 dependencies = [
  "regex",
 ]

--- a/example.yaml
+++ b/example.yaml
@@ -24,13 +24,13 @@
 #       packets: 6
 #       secs: 5
 #
-# (default 25) The cache_threshold statement takes one integer parameter with
+# (default 0) The cache_threshold statement takes one integer parameter with
 # allowed values between 0 (disabled) and 100. This parameter expresses the
 # percentage of the total lease time, measured from the beginning,
 # during which a client's attempt to renew its lease will result
 # in getting the already assigned lease, rather than an extended lease.
 #
-# cache_threshold: 25
+# cache_threshold: 0
 #
 # Dora binds to inaddr_any, if an interface is specified dora will filter
 # all traffic not from this interface.

--- a/libs/config/src/wire/mod.rs
+++ b/libs/config/src/wire/mod.rs
@@ -67,7 +67,7 @@ pub const fn default_rapid_commit() -> bool {
 }
 
 pub fn default_cache_threshold() -> u32 {
-    25
+    0
 }
 
 impl From<MinMax> for LeaseTime {


### PR DESCRIPTION
Had meant to disable this by default. If we ever store all leases in memory as the first stop, then maybe we can make it the default again.